### PR TITLE
Fix parsing of unversioned cask packages.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changelog
 * Add simple CLI unittests. Closes #2.
 * Implement ``outdated`` CLI sub-command.
 * Allow selection of table rendering.
+* Fix parsing of unversionned cask packages.
 
 
 `1.8.0 (2016-08-22) <https://github.com/kdeldycke/meta-package-manager/compare/v1.7.0...v1.8.0>`_

--- a/meta_package_manager.7h.py
+++ b/meta_package_manager.7h.py
@@ -240,9 +240,11 @@ class Cask(Homebrew):
         for installed_pkg in output.strip().split('\n'):
             if not installed_pkg:
                 continue
-            name, versions = installed_pkg.split(' ', 1)
+            infos = installed_pkg.split(' ', 1)
+            name = infos[0]
 
             # Use heuristics to guess installed version.
+            versions = infos[1] if len(infos) > 1 else ''
             versions = sorted([
                 v.strip() for v in versions.split(',') if v.strip()])
             if len(versions) > 1 and 'latest' in versions:

--- a/meta_package_manager/managers/homebrew.py
+++ b/meta_package_manager/managers/homebrew.py
@@ -188,9 +188,11 @@ class Cask(PackageManager):
         for installed_pkg in output.strip().split('\n'):
             if not installed_pkg:
                 continue
-            name, versions = installed_pkg.split(' ', 1)
+            infos = installed_pkg.split(' ', 1)
+            name = infos[0]
 
             # Use heuristics to guess installed version.
+            versions = infos[1] if len(infos) > 1 else ''
             versions = sorted([
                 v.strip() for v in versions.split(',') if v.strip()])
             if len(versions) > 1 and 'latest' in versions:


### PR DESCRIPTION
Unversioned cask packages are not properly parsed.

If cask outputs:
```shell
$ brew cask list --versions
bitcoin-core 
$
```

Then mpm fails to parse the output because of trailing spaces clean up:
```python
Traceback (most recent call last):
  File "./meta_package_manager.7h.py", line 619, in <module>
    print_menu()
  File "./meta_package_manager.7h.py", line 568, in print_menu
    map(methodcaller('sync'), managers)
  File "./meta_package_manager.7h.py", line 243, in sync
    name, versions = installed_pkg.split(' ', 1)
ValueError: need more than 1 value to unpack
```

This PR fix the issue:
![screen shot 2016-09-23 at 12 43 57](https://cloud.githubusercontent.com/assets/159718/18783574/bc5d9e2e-818c-11e6-83cd-c32422100286.png)
