### PR TITLE
Fix parsing when there are no casks installed

### DIFF
--- a/meta_package_manager/managers/homebrew.py
+++ b/meta_package_manager/managers/homebrew.py
@@ -228,6 +228,10 @@ class HomebrewCask(Homebrew):
         # List installed packages.
         output = self.run(
             [self.cli_path] + self.cli_args + ['list', '--versions'])
+        
+        # If there are no packages installed, then don't attempt to parse
+        if not output:
+            return
 
         # Inspect package one by one as `brew cask list` is not reliable. See:
         # https://github.com/caskroom/homebrew-cask/blob/master/doc


### PR DESCRIPTION
If you have no casks installed, then mpm errors out
```
~ ●» brew cask list --versions
Warning: nothing to list
~ ●» mpm outdated
Sync npm package info...
Sync mas package info...
Sync pip3 package info...
Sync pip2 package info...
Sync cask package info...
Traceback (most recent call last):
  File "/usr/local/bin/mpm", line 11, in <module>
    load_entry_point('meta-package-manager==2.3.0', 'console_scripts', 'mpm')()
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/meta_package_manager/cli.py", line 193, in outdated
    manager.sync()
  File "/usr/local/lib/python2.7/site-packages/meta_package_manager/managers/homebrew.py", line 235, in sync
    for installed_pkg in output.split('\n'):
AttributeError: 'NoneType' object has no attribute 'split'
```