### PR TITLE
Fix version check for Homebrew Cask

### DIFF
--- a/meta_package_manager/managers/homebrew.py
+++ b/meta_package_manager/managers/homebrew.py
@@ -237,7 +237,7 @@ class HomebrewCask(Homebrew):
     cli_args = ['cask']
 
     # 1.1.12 is the first to introduce `brew cask outdated`.
-    requirement = '>= 1.1.12'
+    requirement = '>= 1.1.12-*'
 
     id = "cask"
 


### PR DESCRIPTION
Need a LegacyVersion for Homebrew Cask.  Without it, newer versions of Homebrew Cask fail to be 
validated.  Further details in my comment on #41.

Fixes #41 .