### PR TITLE
Fix homebrew version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Fix homebrew version.
+
 
 `2.8.0 (2019-01-03) <https://github.com/kdeldycke/meta-package-manager/compare/v2.7.0...v2.8.0>`_
 -------------------------------------------------------------------------------------------------

--- a/meta_package_manager/managers/homebrew.py
+++ b/meta_package_manager/managers/homebrew.py
@@ -61,7 +61,7 @@ class Homebrew(PackageManager):
         """
         output = self.run([self.cli_path] + self.cli_args + ['--version'])
         if output:
-            return output.split()[1]
+            return output.split()[1].split('-')[0]
 
     @cachedproperty
     def sync(self):


### PR DESCRIPTION
If you ever used `brew update-reset` or similar git commands, like `cd $(brew --repository) && git fetch && git reset --hard origin/master`, Homebrew internally switch from stable release update to git checkout.

And because Homebrew internally using git to [display version](https://github.com/Homebrew/brew/blob/d607fdfcfe69959c8c8e8daa300a2c9a8d186855/Library/Homebrew/brew.sh#L64), this means the version output switch from `Homebrew 2.0.1` to something like this: `Homebrew 2.0.1-10-g7ce517c`. This is not compatible with [packaging.version.parse](https://packaging.pypa.io/en/latest/version/#packaging.version.parse).

This attempt removes everything from the first dash.

Fix #49 