### PR TITLE
Add opkg as package manager

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
 .. note:: This version is not yet released and is under active development.
 
 * Add support for Flatpak on Linux.
+* Add support for opkg on Linux.
 
 
 `2.8.0 (2019-01-03) <https://github.com/kdeldycke/meta-package-manager/compare/v2.7.0...v2.8.0>`_

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ Package manager  Version     macOS  Linux  Windows  ``sync``  ``installed``  ``s
 |apt|__           >= 1.0.0          ✓               ✓         ✓              ✓                        ✓             ✓
 |composer|__      >= 1.4.0   ✓      ✓               ✓         ✓              ✓                        ✓             ✓
 |flatpak|__       >= 1.2.*          ✓                         ✓              ✓                        ✓             ✓
+|opkg|__          >= 0.2.0          ✓               ✓         ✓              ✓                        ✓             ✓
 ================ =========== ====== ====== ======== ========= ============== =========== ============ ============= ============
 
 .. |brew| replace::
@@ -108,6 +109,9 @@ __ https://getcomposer.org
 .. |flatpak| replace::
    Flatpak
 __ https://flatpak.org
+.. |opkg| replace::
+   opkg
+__ https://git.yoctoproject.org/cgit/cgit.cgi/opkg/
 
 
 If you're bored, feel free to add support for new package manager. See

--- a/meta_package_manager/managers/opkg.py
+++ b/meta_package_manager/managers/opkg.py
@@ -48,8 +48,8 @@ class OPKG(PackageManager):
 
         .. code-block:: shell-session
 
-            $ apt --version
-            apt 1.2.15 (amd64)
+            $ opkg --version
+            opkg version 0.3.6 (libsolv 0.7.5)
         """
         output = self.run([self.cli_path, '--version'])
         if output:

--- a/meta_package_manager/managers/opkg.py
+++ b/meta_package_manager/managers/opkg.py
@@ -37,7 +37,7 @@ class OPKG(PackageManager):
 
     platforms = frozenset([LINUX])
 
-    requirement = '>= 1.0.0'
+    requirement = '>= 0.2.0'
 
     name = "OPKG"
 

--- a/meta_package_manager/managers/opkg.py
+++ b/meta_package_manager/managers/opkg.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018 Kevin Deldycke <kevin@deldycke.com>
+#                         and contributors.
+# All Rights Reserved.
+#
+# This program is Free Software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
+
+import re
+
+from boltons.cacheutils import cachedproperty
+
+from ..base import PackageManager
+from ..platform import LINUX
+
+
+class OPKG(PackageManager):
+
+    platforms = frozenset([LINUX])
+
+    requirement = '>= 1.0.0'
+
+    name = "OPKG"
+
+    def get_version(self):
+        """ Fetch version from ``opkg --version`` output.
+
+        Raw CLI output samples:
+
+        .. code-block:: shell-session
+
+            $ apt --version
+            apt 1.2.15 (amd64)
+        """
+        output = self.run([self.cli_path, '--version'])
+        if output:
+            return output.split('\n')[0].split()[2]
+
+    @cachedproperty
+    def sync(self):
+        """
+
+        Raw CLI output samples:
+
+        .. code-block:: shell-session
+        """
+        super(OPKG, self).sync
+        self.run([self.cli_path] + self.cli_args + ['update'])
+
+    @cachedproperty
+    def installed(self):
+        """ Fetch installed packages from ``opkg list-installed`` output.
+
+        Raw CLI output samples:
+
+        .. code-block:: shell-session
+            $ opkg list-installed
+            3rd-party-feed-configs - 1.1-r0
+            aio-grab - 1.0+git71+c79e264-r0
+            alsa-conf - 1.1.9-r0
+            alsa-state - 0.2.0-r5
+            alsa-states - 0.2.0-r5
+            alsa-utils-alsactl - 1.1.9-r0
+            avahi-daemon - 0.7-r0
+            base-files - 3.0.14-r89
+            base-files-dev - 3.0.14-r89
+            base-passwd - 3.5.29-r0
+            bash - 5.0-r0
+            bash-completion - 2.9-r0
+            bash-completion-dev - 2.9-r0
+            bash-dev - 5.0-r0
+            binutils - 2.32.0-r0
+            busybox - 1.31.0-r0
+            busybox-inetd - 1.31.0-r0
+            busybox-mdev - 1.31.0-r0
+            busybox-syslog - 1.31.0-r0
+            busybox-udhcpc - 1.31.0-r0
+        """
+        installed = {}
+
+        output = self.run([self.cli_path] + self.cli_args + [
+            'list-installed'])
+
+        if output:
+            regexp = re.compile(r'(\S+) - (\S+)')
+            for package in output.split('\n'):
+                match = regexp.match(package)
+                if match:
+                    package_id, installed_version = match.groups()
+                    installed[package_id] = {
+                        'id': package_id,
+                        'name': package_id,
+                        'installed_version': installed_version}
+
+        return installed
+
+    def search(self, query):
+        """ opkg doesn't have a working 'search', so get all packages and filter the packages
+        Raw CLI output samples:
+
+        .. code-block:: shell-session
+
+        """
+        matches = {}
+
+        output = self.run([self.cli_path] + self.cli_args + ['list'])
+
+        if output:
+            regexp = re.compile(r'(\S+) - (\S+) - (.+)')
+            for package in output.split('\n'):
+                match = regexp.match(package)
+                if match:
+                    package_id, latest_version, description = match.groups()
+                    if query in package_id:
+                        matches[package_id] = {
+                            'id': package_id,
+                            'name': package_id,
+                            'latest_version': latest_version,
+                            'exact': self.exact_match(query, package_id)}
+        return matches
+
+    @cachedproperty
+    def outdated(self):
+        """ Fetch outdated packages from ``opkg list-upgradable`` output.
+
+        Raw CLI output samples:
+
+        .. code-block:: shell-session
+
+            $ opkg list-upgradable
+            enigma2-plugin-extensions-mediascanner - 2.7+git17720+55c6b34-r0 - 2.7+git17722+daf2f52-r0
+            openpli-bootlogo - 20190717-r0 - 20190718-r0
+            enigma2-plugin-extensions-pictureplayer - 2.7+git17720+55c6b34-r0 - 2.7+git17722+daf2f52-r0
+            enigma2-plugin-systemplugins-fastscan - 2.7+git17720+55c6b34-r0 - 2.7+git17722+daf2f52-r0
+            enigma2-plugin-systemplugins-hotplug - 2.7+git17720+55c6b34-r0 - 2.7+git17722+daf2f52-r0
+        """
+        outdated = {}
+
+        output = self.run([self.cli_path] + self.cli_args + [
+            'list-upgradable'])
+
+        if output:
+            regexp = re.compile(r'(\S+) - (\S+) - (\S+)')
+            for package in output.split('\n'):
+                match = regexp.match(package)
+                if match:
+                    package_id, installed_version, latest_version = \
+                        match.groups()
+                    outdated[package_id] = {
+                        'id': package_id,
+                        'name': package_id,
+                        'latest_version': latest_version,
+                        'installed_version': installed_version}
+
+        return outdated
+
+    def upgrade_cli(self, package_id=None):
+        cmd = [self.cli_path] + self.cli_args + ['upgrade']
+        if package_id:
+            cmd.append(package_id)
+        return cmd
+
+    def upgrade_all_cli(self):
+        return self.upgrade_cli()

--- a/meta_package_manager/tests/test_cli.py
+++ b/meta_package_manager/tests/test_cli.py
@@ -106,6 +106,7 @@ class TestCLISubcommand(CLITestCase):
         self.assertNotIn(" pip3", result.output)
         self.assertNotIn(" gem", result.output)
         self.assertNotIn(" flatpak", result.output)
+        self.assertNotIn(" opkg", result.output)
 
         result = self.invoke(
             '--manager', 'npm', '--manager', 'gem', *self.subcommand_args)
@@ -119,6 +120,7 @@ class TestCLISubcommand(CLITestCase):
         self.assertNotIn(" pip2", result.output)
         self.assertNotIn(" pip3", result.output)
         self.assertNotIn(" flatpak", result.output)
+        self.assertNotIn(" opkg", result.output)
 
 
 class TestCLITableRendering(TestCLISubcommand):
@@ -178,7 +180,7 @@ class TestCLIManagers(TestCLITableRendering):
 
         self.assertSetEqual(set(result), set([
             'apm', 'apt', 'brew', 'cask', 'composer', 'gem', 'mas', 'npm',
-            'pip2', 'pip3', 'flatpak']))
+            'pip2', 'pip3', 'flatpak', 'opkg']))
 
         for manager_id, info in result.items():
             self.assertIsInstance(manager_id, basestring)
@@ -217,7 +219,7 @@ class TestCLIInstalled(TestCLITableRendering):
 
         self.assertTrue(set(result).issubset([
             'apm', 'apt', 'brew', 'cask', 'composer', 'gem', 'mas', 'npm',
-            'pip2', 'pip3', 'flatpak']))
+            'pip2', 'pip3', 'flatpak', 'opkg']))
 
         for manager_id, info in result.items():
             self.assertIsInstance(manager_id, basestring)
@@ -253,7 +255,7 @@ class TestCLISearch(TestCLITableRendering):
 
         self.assertTrue(set(result).issubset([
             'apm', 'apt', 'brew', 'cask', 'composer', 'gem', 'mas', 'npm',
-            'pip2', 'pip3', 'flatpak']))
+            'pip2', 'pip3', 'flatpak', 'opkg']))
 
         for manager_id, info in result.items():
             self.assertIsInstance(manager_id, basestring)
@@ -306,7 +308,7 @@ class TestCLIOutdated(TestCLITableRendering):
 
         self.assertTrue(set(result).issubset([
             'apm', 'apt', 'brew', 'cask', 'composer', 'gem', 'mas', 'npm',
-            'pip2', 'pip3', 'flatpak']))
+            'pip2', 'pip3', 'flatpak', 'opkg']))
 
         for manager_id, info in result.items():
             self.assertIsInstance(manager_id, basestring)

--- a/meta_package_manager/tests/test_managers.py
+++ b/meta_package_manager/tests/test_managers.py
@@ -46,7 +46,7 @@ class TestManagerDefinitions(unittest.TestCase):
 
     def test_number(self):
         """ Check all implemented package managers are accounted for. """
-        self.assertEqual(len(pool()), 11)
+        self.assertEqual(len(pool()), 12)
 
     def test_platforms_type(self):
         """ Check that definitions returns supported platforms as a frozenset.
@@ -149,7 +149,7 @@ class TestManagerPlatform(unittest.TestCase):
         supported_managers = {m.id for m in pool().values() if m.supported}
         self.assertSetEqual(supported_managers, set([
             'apm', 'apt', 'composer', 'gem', 'npm', 'pip2', 'pip3',
-            'flatpak']))
+            'flatpak', 'opkg']))
 
     @unless_windows()
     def test_windows(self):


### PR DESCRIPTION
opkg is a lightweight package manager, from the syntax similar to apt, often used in embedded linux systems.

It also (maybe) adds a falsehood: You can search for a package in a package manager.
opkg has no search command, you have to list all packages and then perform a grep or something like that.