### PR TITLE
Updates homebrew run on Linux

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,6 +53,10 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
+      - name: Linux - Install npm
+        if: runner.os == 'Linux'
+        run: |
+          brew update || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
       # Apt
       - name: Linux - Upgrade apt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,7 +58,7 @@ jobs:
         # Use Github url shortener for brew (un)install script to avoid line to
         # long error from yamllint.
         run: |
-          brew update || /bin/bash -c "$(curl -fsSL "https://git.io/JIY6g)"
+          brew update || /bin/bash -c "$(curl -fsSL "https://git.io/JIY6g")"
 
       # Apt
       - name: Linux - Upgrade apt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,10 +53,12 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-      - name: Linux - Install npm
+      - name: Linux - Upgrade or Install Homebrew
         if: runner.os == 'Linux'
+        # Use Github url shortener for brew (un)install script to avoid line to
+        # long error from yamllint.
         run: |
-          brew update || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          brew update || /bin/bash -c "$(curl -fsSL "https://git.io/JIY6g)"
 
       # Apt
       - name: Linux - Upgrade apt


### PR DESCRIPTION
First off, thanks for the great tool :)

This PR adds [Linux as a supported platform for Homebrew](https://docs.brew.sh/Homebrew-on-Linux). After adding LINUX to the list of supported platforms, `brew` didn't return a list of installed software. It turns out that brew on Linux needs the path to `brew` to remain a symlink to properly list installed packages.

```
# Returns nothing.
/home/linuxbrew/.linuxbrew/Homebrew/bin/brew list --versions
```

```
# Returns the list as expected.
/home/linuxbrew/.linuxbrew/bin/brew list --versions
```

The fix was to override the `cli_path` method to get the cli path without following the symlink.

```
# Homebrew on linux uses the symlink path to set environment variables.
cli_path = Path.cwd() / Path(cli_path)
```

The method could be removed from this class if base.py was altered instead.