### PR TITLE
`apt-mint`: `--names-only` is not supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,8 @@ flycheck_*.el
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -268,7 +269,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 ### Vim ###
 # Swap

--- a/meta_package_manager/managers/apt.py
+++ b/meta_package_manager/managers/apt.py
@@ -131,7 +131,7 @@ class APT(PackageManager):
 
         .. code-block:: shell-session
 
-            ► apt search abc --quiet --names-only
+            ► apt search abc --quiet
             Sorting...
             Full Text Search...
             abcde/xenial 2.7.1-1 all
@@ -151,7 +151,7 @@ class APT(PackageManager):
 
         .. code-block:: shell-session
 
-            ► apt search "^sed$" --quiet --names-only
+            ► apt search "^sed$" --quiet
             Sorting...
             Full Text Search...
             sed/xenial 2.1.9-3 all
@@ -179,7 +179,7 @@ class APT(PackageManager):
         """
         matches = {}
 
-        search_arg = "--names-only"
+        search_arg = ""
         if exact:
             # Realy on apt regexp support to speed-up exact match.
             query = f"^{query}$"


### PR DESCRIPTION
Not using it displays the right package because on search an exact name match is passed (in the fix `--names-only` is not passed)

```
debug: Try to install libgit2-dev with apt.
debug: ► /usr/local/bin/apt search ^libgit2-dev$ --quiet --names-only
```