### PR TITLE
Fix some typos in the documentation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -359,7 +359,7 @@ This version is not released yet and is under active development.
 - \[mpm\] Auto-fix common typos.
 - \[mpm\] Lint JSON files.
 - \[mpm\] Automate GitHub label generation and synchronization.
-- \[mpm\] Automaticcaly applies labels on PRs and issues depending on their
+- \[mpm\] Automatically applies labels on PRs and issues depending on their
   changed files and content.
 - \[mpm\] Check label rules against manager definitions. Adds development
   dependency on `PyYAML`.

--- a/meta_package_manager/bar_plugin/meta_package_manager.7h.py
+++ b/meta_package_manager/bar_plugin/meta_package_manager.7h.py
@@ -24,7 +24,7 @@ Minimal requirement is macOS Catalina (10.15) for both Xbar and SwiftBar.
 Catalina deprecates Python 2.x, and ships with Python 3.7.3. So this plugin is
 required to work with Python 3.7.3 or newer.
 
-- Xbar automaticcaly bridge plugin options between its UI and environment
+- Xbar automatically bridge plugin options between its UI and environment
   variable on script execution. See:
   https://xbarapp.com/docs/2021/03/14/variables-in-xbar.html
 

--- a/meta_package_manager/base.py
+++ b/meta_package_manager/base.py
@@ -126,21 +126,21 @@ class PackageManager:
 
     Should be a list of strings whose order dictatate the search sequence.
 
-    Most of the time unnecessay: :py:func:`meta_package_manager.base.PackageManager.cli_path`
+    Most of the time unnecessary: :py:func:`meta_package_manager.base.PackageManager.cli_path`
     works well on all platforms.
     """
 
     extra_env = None
     """Additional environment variables to add to the current context.
 
-    Automaticcaly applied on each :py:func:`meta_package_manager.base.PackageManager.run_cli`
+    Automatically applied on each :py:func:`meta_package_manager.base.PackageManager.run_cli`
     calls.
     """
 
     pre_cmds = ()
     """Global list of pre-commands to add before before invoked CLI.
 
-    Automaticcaly added to each :py:func:`meta_package_manager.base.PackageManager.run_cli`
+    Automatically added to each :py:func:`meta_package_manager.base.PackageManager.run_cli`
     call.
 
     Used to prepend `sudo <https://www.sudo.ws>`_ or other system utilities.
@@ -150,7 +150,7 @@ class PackageManager:
     post_args = ()
     """Global list of options used before and after the invoked package manager CLI.
 
-    Automaticcaly added to each :py:func:`meta_package_manager.base.PackageManager.run_cli`
+    Automatically added to each :py:func:`meta_package_manager.base.PackageManager.run_cli`
     call.
 
     Essentially used to force silencing, low verbosity or no-color output.
@@ -172,7 +172,7 @@ class PackageManager:
     """Tell the manager to either raise or continue on errors."""
 
     ignore_auto_updates = True
-    """Some managers can report or ignore packages which have their own auto-update mecanism.
+    """Some managers can report or ignore packages which have their own auto-update mechanism.
     """
 
     dry_run = False
@@ -195,7 +195,7 @@ class PackageManager:
     def cli_path(self):
         """Fully qualified path to the package manager CLI.
 
-        Automaticaly search the location of the CLI in the system. Try multiple CLI
+        Automatically search the location of the CLI in the system. Try multiple CLI
         names within several system path.
 
         Only checks if the file exists. Its executability will be assessed later. See
@@ -327,7 +327,7 @@ class PackageManager:
 
     @classmethod
     def args_cleanup(cls, *args):
-        """Flatten recusive iterables, remove all ``None``, and cast each element to
+        """Flatten recursive iterables, remove all ``None``, and cast each element to
         strings.
 
         Helps serialize :py:class:`pathlib.Path` and :py:class:`meta_package_manager.version.TokenizedString` objects.


### PR DESCRIPTION
Just fixing some typos I found while reading through the code. Thanks @kdeldycke for such a cool project. :)