### PR TITLE
Optimise cargo search

### DIFF
--- a/meta_package_manager/managers/cargo.py
+++ b/meta_package_manager/managers/cargo.py
@@ -69,7 +69,10 @@ class Cargo(PackageManager):
 
         output = self.run_cli("search", "--color", "never", "--quiet", "--limit", "100", query)
 
-        regexp = re.compile(r"(?P<package_id>.+)\s+=\s+\"(?P<version>.+)\"\s+#\s+(?P<description>.+)")
+        regexp = re.compile(
+            r"^(?P<package_id>\S+)\s+=\s+\"(?P<version>\S+)\"\s+#\s+(?P<description>.+)$",
+            re.MULTILINE,
+        )
 
         for package_id, version, description in regexp.findall(output):
 


### PR DESCRIPTION
Just pulling in some optimisations from my version of the `search` function for cargo. I think this version is about 50% faster from running some simple benchmarks, mostly because of the multiline search which means the regex never tries to search across multiple lines. If this PR is accepted I might look at some other functions to see of they can be sped up as well. :)