### PR TITLE
Fix `test_docs.py::test_labeller_rules`

### DIFF
--- a/meta_package_manager/tests/test_docs.py
+++ b/meta_package_manager/tests/test_docs.py
@@ -129,7 +129,7 @@ def test_labeller_rules():
 
     assert rules_labels
     # Check that all canonical labels are referenced in rules.
-    assert (canonical_labels - {"🔌 bar-plugin", "📦 manager: mpm"}).issubset(
+    assert (canonical_labels - {"🔌 bar-plugin", "📦 manager: apm"}).issubset(
         rules_labels
     )
 


### PR DESCRIPTION
This fixes a test, because the label `📦 manager: mpm` doesn't exist in the yaml file.
With this fix, pytest runs without failures.