### PR TITLE
Fix apt omitting final result

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 This version is not released yet and is under active development.
 ```
 
+- \[apt\] Fix omission of the final result in an `apt` (non-mint) search.
 - \[mpm\] Update `brew` installation instructions now that `mpm` is available in official Homebrew repository.
 
 ## {gh}`5.13.0 (2023-03-31) <compare/v5.12.0...v5.13.0>`

--- a/meta_package_manager/managers/apt.py
+++ b/meta_package_manager/managers/apt.py
@@ -196,7 +196,7 @@ class APT(PackageManager):
             \                     # A space.
             (?:.+)\n              # Any content ending the line.
             (?P<description>      # Start of the multi-line desc group.
-                (?:\ \ .+\n)+     # Lines of content prefixed by 2 spaces.
+                (?:\ \ .+\n?)+    # Line(s) of content prefixed by 2 spaces.
             )
             """,
             re.MULTILINE | re.VERBOSE,

--- a/meta_package_manager/tests/test_manager_apt.py
+++ b/meta_package_manager/tests/test_manager_apt.py
@@ -1,0 +1,45 @@
+# Copyright Kevin Deldycke <kevin@deldycke.com> and contributors.
+#
+# This program is Free Software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+from __future__ import annotations
+
+import pytest
+import subprocess
+
+@pytest.fixture
+def exact_search():
+    def _exact_search(package_id):
+        process = subprocess.run(
+                ("apt", "search", f"^{package_id}$"),
+                capture_output=True,
+                encoding="utf-8",
+        )
+        assert process.returncode == 0
+        return process.stdout
+
+    yield _exact_search
+
+class TestAptSearch:
+    def test_nonempty_exact_result(self, invoke, exact_search):
+        # Search for a package by the exact name, and check that apt finds it.
+        output = exact_search("snapd")
+        assert "snapd/" in output
+
+        # Check that mpm recognizes that package.
+        result = invoke("--apt", "search", "--exact", "snapd")
+        assert result.exit_code == 0
+        assert "snapd" in result.stdout
+        assert "apt" in result.stdout


### PR DESCRIPTION
My old issue (#881) was still giving me trouble with the latest version of `meta-package-manager`. This time I cracked it open and fiddled with the regex until I found the problem: it's expecting a newline in the description. This works great for a verbose search where most descriptions are multiple lines, but in practice (i.e. when using `install` or `search --exact`), the descriptions are one line, without a trailing newline. It's kinda hard to catch because an inexact search will show a few results, but it's always one fewer than `apt search` gets you.

I just changed the literal `\n` to `\n?`, so it should be backwards compatible as well.

`apt-mint` doesn't look for newlines and I don't use mint, so I didn't touch that.

I also added a unit test per the development guidelines. It's my first unit test in Python, let me know if I over- or under-did it. Thanks!