### PR TITLE
feat(dnf5): add dnf 5 compatible

### DIFF
--- a/meta_package_manager/managers/dnf.py
+++ b/meta_package_manager/managers/dnf.py
@@ -40,7 +40,7 @@ class DNF(PackageManager):
 
     requirement = "4.0.0"
 
-    cli_names = ("dnf",)
+    cli_names = ("dnf4",)
     """
     .. code-block:: shell-session
 
@@ -65,12 +65,15 @@ class DNF(PackageManager):
             audit-libs 2.2.53-1.el8 audit_libs_dummary x86_64
             (...)
         """
-        qf = ["%{name}", "%{version}", "%{summary}", "%{arch}"]
+        qf = ["%{name}", "%{version}", "%{summary}", "%{arch}\n"]
         output = self.run_cli(
             "repoquery", "--userinstalled", "--qf", DNF.DELIMITER.join(qf)
         )
 
         for line_package in output.splitlines():
+            # remove empty new line
+            if not line_package:
+                continue
             package_id, installed_version, summary, arch = line_package.split(
                 DNF.DELIMITER
             )
@@ -94,10 +97,13 @@ class DNF(PackageManager):
             audit-libs 2.2.53-1.el8 2.6.53-1.el8 audit_libs_dummary x86_64
             (...)
         """
-        qf = ["%{name}", "%{version}", "%{evr}", "%{summary}", "%{arch}"]
+        qf = ["%{name}", "%{version}", "%{evr}", "%{summary}", "%{arch}\n"]
         output = self.run_cli("repoquery", "--upgrades", "--qf", DNF.DELIMITER.join(qf))
 
         for line_package in output.splitlines():
+            # remove empty new line
+            if not line_package:
+                continue
             package_id, installed_version, last_version, summary, arch = (
                 line_package.split(DNF.DELIMITER)
             )
@@ -211,6 +217,13 @@ class DNF(PackageManager):
         """
 
         return self.run_cli("--assumeyes", "autoremove", package_id, sudo=True)
+
+
+class DNF5(DNF):
+    homepage_url = "https://github.com/rpm-software-management/dnf5"
+    requirement = "5.0.0"
+    cli_names = ("dnf5",)
+    pre_args = ()
 
 
 class YUM(DNF):

--- a/meta_package_manager/pool.py
+++ b/meta_package_manager/pool.py
@@ -31,7 +31,7 @@ from .managers.apt import APT, APT_Mint
 from .managers.cargo import Cargo
 from .managers.chocolatey import Choco
 from .managers.composer import Composer
-from .managers.dnf import DNF, YUM
+from .managers.dnf import DNF, DNF5, YUM
 from .managers.emerge import Emerge
 from .managers.flatpak import Flatpak
 from .managers.gem import Gem
@@ -65,6 +65,7 @@ manager_classes = (
     Choco,
     Composer,
     DNF,
+    DNF5,
     Emerge,
     Flatpak,
     Gem,


### PR DESCRIPTION
Hey, Fedora 41 have is new dnf version 5 with some minor change:

1. repoquery return format in oneline (so add `\n` and remove empty line)
2. `--color=never` dosen't exists