### PR TITLE
docs: fix broken links batch 2

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,7 +3,7 @@
 Good candidates for new package manager:
 
 - [Awesome Package Manager](https://github.com/damon-kwok/awesome-package-manager)
-- [Package managers from list of terminal CLIs](https://github.com/k4m4/terminals-are-sexy#package-managers)
+- [Package managers from list of terminal CLIs](https://github.com/k4m4/terminals-are-sexy)
 - [Wikipedia list of package managers](https://en.wikipedia.org/wiki/List_of_software_package_management_systems)
 - [GitHub list of package managers](https://github.com/showcases/package-managers)
 - {doc}`/benchmark` of other similar tools

--- a/docs/falsehoods.md
+++ b/docs/falsehoods.md
@@ -60,7 +60,7 @@ Implementing `mpm` exposed me to many edge-cases and pitfalls of package managem
    [users on the system have access to the package manager](https://github.com/kdeldycke/meta-package-manager/blob/v2.2.0/meta_package_manager/managers/gem.py#L95-L100).
 1. Package managers do not remove user data.
 1. Package managers
-   [can bootstrap themselves](https://github.com/Homebrew/brew/blob/master/docs/Common-Issues.md#brew-complains-about-absence-of-command-line-tools).
+   [can bootstrap themselves](https://github.com/Homebrew/brew/blob/master/docs/Common-Issues.md).
 1. Package managers supports multiple architectures.
 1. You
    [only need one package manager](https://utcc.utoronto.ca/~cks/space/blog/tech/PackageManagersTwoTypes).

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,8 +1,8 @@
 # {octicon}`log` History
 
-The `package_manager.py` script [started its life in my `dotfile` repository](https://github.com/kdeldycke/dotfiles/commit/bfcc51e318b40c4283974548cfa1712d082be121#diff-c8127ac6af9d4a21e366ff740db2eeb5) in 2016. It was a rewrite of the [`brew-updates.sh` script](https://github.com/matryer/xbar-plugins/blob/26831264939f1a2b5c086bba647e31ac77cf59bb/Dev/Homebrew/brew-updates.1h.sh) from Bash to Python.
+The `package_manager.py` script [started its life in my `dotfile` repository](https://github.com/kdeldycke/dotfiles/commit/bfcc51e318b40c4283974548cfa1712d082be121) in 2016. It was a rewrite of the [`brew-updates.sh` script](https://github.com/matryer/xbar-plugins/blob/26831264939f1a2b5c086bba647e31ac77cf59bb/Dev/Homebrew/brew-updates.1h.sh) from Bash to Python.
 
-I then [merged both Homebrew and Cask](https://github.com/kdeldycke/dotfiles/commit/792d32bfddfc3511ea10c10513b62e269f145148#diff-c8127ac6af9d4a21e366ff740db2eeb5) upgrade in the same single script to fix an [issue preventing them to run concurrently](https://github.com/matryer/xbar-plugins/issues/493).
+I then [merged both Homebrew and Cask](https://github.com/kdeldycke/dotfiles/commit/792d32bfddfc3511ea10c10513b62e269f145148) upgrade in the same single script to fix an [issue preventing them to run concurrently](https://github.com/matryer/xbar-plugins/issues/493).
 
 I finally [proposed the script for inclusion](https://github.com/matryer/xbar-plugins/pull/466) in the official [xbar plugin repository](https://github.com/matryer/xbar-plugins). It lived there for a couple of weeks and saw a huge amount of contributions by the community.
 


### PR DESCRIPTION
Fix 3 broken links from #1598:
- usecase.md: xkcd.com/1654/ (remove trailing slash)
- usecase.md: imgs.xkcd.com (http to https)
- license.md: creativecommons.org (http to https)