### PR TITLE
docs: fix broken links batch 5

### DIFF
--- a/docs/bar-plugin.md
+++ b/docs/bar-plugin.md
@@ -86,7 +86,7 @@ $ mpm --bar-plugin-path
 ~/Library/Python/3.11/lib/python/site-packages/meta_package_manager/bar_plugin.py
 ```
 
-This option is handy for deployment and initial configuration of Xbar/SwiftBar. I [use this in my dotfiles](https://github.com/kdeldycke/dotfiles/blob/c04296d29e5f5ce48687f79554b265b3e89d5dbb/install.sh#L230) to symlink the plugin to its latest version:
+This option is handy for deployment and initial configuration of Xbar/SwiftBar. I [use this in my dotfiles](https://github.com/kdeldycke/dotfiles/blob/c04296d29e5f5ce48687f79554b265b3e89d5dbb/install.sh) to symlink the plugin to its latest version:
 
 ```shell-session
 $ ln -sf "$(mpm --bar-plugin-path)" "${HOME}/Library/Application Support/xbar/plugins/mpm.7h.py"

--- a/docs/falsehoods.md
+++ b/docs/falsehoods.md
@@ -8,15 +8,15 @@ Implementing `mpm` exposed me to many edge-cases and pitfalls of package managem
 1. A package has only one name (see {issue}`26`).
 1. A package name is unique.
 1. Package
-   [names are composed of ASCII characters](https://github.com/kdeldycke/meta-package-manager/blob/v2.2.0/meta_package_manager/managers/homebrew.py#L205-L206).
+   [names are composed of ASCII characters](https://github.com/kdeldycke/meta-package-manager/blob/v2.2.0/meta_package_manager/managers/homebrew.py).
 1. A package name is the same as its ID (see {issue}`11`).
 1. There is only one way to install a package.
 1. Only one version of a package is available on a system.
 1. Shared [dependencies are always compatible](https://en.wikipedia.org/wiki/Dependency_hell).
 1. [Version selection is guaranteed to run fast](https://research.swtch.com/version-sat).
 1. All
-   [packages have a version](https://github.com/kdeldycke/meta-package-manager/blob/v2.2.0/meta_package_manager/managers/mas.py#L71-L75).
-1. [Versioned packages are immutable](https://github.com/kdeldycke/meta-package-manager/blob/v2.2.0/meta_package_manager/managers/homebrew.py#L230-L231).
+   [packages have a version](https://github.com/kdeldycke/meta-package-manager/blob/v2.2.0/meta_package_manager/managers/mas.py).
+1. [Versioned packages are immutable](https://github.com/kdeldycke/meta-package-manager/blob/v2.2.0/meta_package_manager/managers/homebrew.py).
 1. Packages can’t upgrade themselves.
 1. A package can be reinstalled.
 


### PR DESCRIPTION
Fix broken links batch 5:

- bar-plugin.md: remove line anchor from dotfiles install.sh link
- falsehoods.md: remove line anchors from 4 code links

Relates to #1598