### PR TITLE
Improves WinGet manager with detailed output parsing and Windows alias detection

### DIFF
--- a/meta_package_manager/base.py
+++ b/meta_package_manager/base.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 from contextlib import nullcontext
@@ -524,6 +525,18 @@ class PackageManager(metaclass=MetaPackageManager):
 
             for filename in search_filenames:
                 file = search_path / filename
+                # On Windows, check for reparse points (e.g., Windows App Execution Aliases like winget).
+                # These return False for is_file() and 0 for getsize(), so we detect them separately.
+                if sys.platform == "win32":
+                    try:
+                        file_stat = file.lstat()
+                        if file_stat.st_file_attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT:
+                            logging.debug(f"CLI found at {highlight_cli_name(file, cli_names)} (reparse point)")
+                            yield file
+                            continue
+                    except OSError:
+                        # Permission denied or file doesn't exist; fall through to normal checks.
+                        pass
                 if not file.is_file() or not os.path.getsize(file):
                     continue
                 logging.debug(f"CLI found at {highlight_cli_name(file, cli_names)}")

--- a/meta_package_manager/base.py
+++ b/meta_package_manager/base.py
@@ -22,7 +22,6 @@ import re
 import shutil
 import stat
 import subprocess
-import sys
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -43,6 +42,7 @@ from extra_platforms import (
     Platform,
     current_platform,
     extract_members,
+    is_any_windows,
 )
 from packageurl import PackageURL
 
@@ -481,7 +481,7 @@ class PackageManager(metaclass=MetaPackageManager):
         # variation of the CLI name with any of these suffixes.
         # Code below is inspired by the original implementation of ``shutil.which()``:
         # https://github.com/python/cpython/blob/8d46c7e/Lib/shutil.py#L1478-L1491
-        if sys.platform == "win32":
+        if is_any_windows():
             pathext_source = os.getenv("PATHEXT") or shutil._WIN_DEFAULT_PATHEXT
             pathext = unique(ext for ext in pathext_source.split(os.pathsep) if ext)
             search_filenames = []
@@ -527,7 +527,7 @@ class PackageManager(metaclass=MetaPackageManager):
                 file = search_path / filename
                 # On Windows, check for reparse points (e.g., Windows App Execution Aliases like winget).
                 # These return False for is_file() and 0 for getsize(), so we detect them separately.
-                if sys.platform == "win32":
+                if is_any_windows():
                     try:
                         file_stat = file.lstat()
                         if file_stat.st_file_attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT:

--- a/meta_package_manager/managers/winget.py
+++ b/meta_package_manager/managers/winget.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+import re
+
 from extra_platforms import WINDOWS
 
 from ..base import PackageManager
@@ -57,13 +59,85 @@ class WinGet(PackageManager):
         - https://github.com/microsoft/winget-cli/issues/3494#issuecomment-3921618377
     """
 
-    version_regexes = (r"v\s+(?P<version>\S+)",)
+    version_regexes = (r"v\s*(?P<version>\S+)",)
     """
     .. code-block:: pwsh-session
 
         PS C:\\Users\\kev> winget --version
-        v1.7.11261
+        Windows Package Manager v1.28.220
     """
+
+    def _parse_details(
+        self, output: str, filter_by_source: bool = False
+    ) -> Iterator[tuple[str, str, str, str | None]]:
+        """Parse --details output from winget list or upgrade-available commands.
+
+        Each package is formatted as:
+            (N/M) <Name> [<Id>]
+            Version: <current_version>
+            Publisher: <publisher>
+            Origin Source: winget
+            ...
+            [Available Upgrades:]
+            [  winget [<latest_version>]]
+
+        If filter_by_source=True, only packages with Origin Source: winget are returned.
+        """
+        # Split on block markers like "(1/232) Package Name [Id]"
+        blocks = re.split(r'(?=^\(\d+/\d+\) )', output, flags=re.MULTILINE)
+
+        for block in blocks:
+            if not block.strip():
+                continue
+
+            lines = block.strip().splitlines()
+            if not lines:
+                continue
+
+            # Parse the header line: (N/M) <Name> [<Id>]
+            header = lines[0]
+            header_match = re.match(
+                r'^\(\d+/\d+\)\s+(.+)\s+\[([^\]]+)\]$',
+                header,
+            )
+            if not header_match:
+                continue
+
+            name = header_match.group(1).strip()
+            package_id = header_match.group(2).strip()
+            version = None
+            origin_source = None
+
+            # Look for version on the next line or in key:value format
+            latest_version = None
+            for i, line in enumerate(lines[1:], 1):
+                line_stripped = line.strip()
+                # Extract version from "Version: X.Y.Z" line
+                if line_stripped.startswith('Version:'):
+                    version = line_stripped.split(':', 1)[1].strip()
+                # Track Origin Source
+                elif line_stripped.startswith('Origin Source:'):
+                    origin_source = line_stripped.split(':', 1)[1].strip()
+                # Look for available upgrades
+                elif line_stripped == 'Available Upgrades:':
+                    # Next non-empty line should have the version.
+                    for future_line in lines[i + 1:]:
+                        future_line = future_line.strip()
+                        if future_line:
+                            # Format: "winget [X.Y.Z]"
+                            upgrade_match = re.search(r'\[([^\]]+)\]', future_line)
+                            if upgrade_match:
+                                latest_version = upgrade_match.group(1)
+                            break
+                    break
+
+            # Only yield if we found a version
+            if version:
+                # Filter by source if requested (only include winget packages)
+                if filter_by_source and origin_source != 'winget':
+                    continue
+
+                yield (name, package_id, version, latest_version)
 
     def _parse_table(self, output: str) -> Iterator[Generator[str, None, None]]:
         """Parse a table from the output of a winget command and returns a generator of cells."""
@@ -113,31 +187,34 @@ class WinGet(PackageManager):
 
         .. code-block:: pwsh-session
 
-            PS C:\\Users\\kev> winget list --accept-source-agreements --disable-interactivity
-            The 'msstore' source requires that you view the following agreements before using.
-            Terms of Transaction: https://aka.ms/microsoft-store-terms-of-transaction
-            The source requires the current machine's 2-letter geographic region to be sent to the backend service to function properly (ex. "US").
+            PS C:\\Users\\kev> winget list --details --accept-source-agreements --disable-interactivity
+            (1/7) CCleaner [CCleaner] Version: 6.08
+            Publisher: Piriform Software Ltd
+            Local Identifier: ARP\\Machine\\X64\\CCleaner
+            Product Code: CCleaner
+            Installer Category: exe
+            Installed Scope: Machine
+            Installed Architecture: X64
+            Installed Locale: en-US
+            Origin Source: winget
+            Available Upgrades:
 
-            Name                          Id                           Version        Available     Source
-            ----------------------------------------------------------------------------------------------
-            CCleaner                      CCleaner                     6.08
-            Git                           Git.Git                      2.37.3         2.45.1        winget
-            Microsoft Edge                Microsoft.Edge               109.0.1518.70  125.0.2535.51 winget
-            Microsoft Edge Update         Microsoft Edge Update        1.3.187.37
-            App Installer                 Microsoft.AppInstaller       1.21.3482.0                  winget
-            Microsoft.UI.Xaml.2.7         Microsoft.UI.Xaml.2.7        7.2208.15002.0               winget
-            Python Launcher               Python.Launchez              < 3.12.0       3.12.0        winget
-            Microsoft Visual C++ (x86)... Microsoft.VCRedist.2015+.X86 14.34.31931.0  14.38.33135.0 winget
+            (2/7) Git [Git.Git] Version: 2.37.3
+            Publisher: The Git Development Community
+            ...
+
+        Only returns packages with Origin Source: winget to exclude packages
+        installed via other sources (e.g., sideload, portable).
         """
-        output = self.run_cli("list")
+        output = self.run_cli("list", "--details")
 
-        for name, package_id, installed_version, _, _ in self._parse_table(output):
-            # Strip the "<" comparison operator from the version.
-            if " " in installed_version:
-                installed_version = installed_version.split()[1]
-
+        for name, package_id, installed_version, _ in self._parse_details(
+            output, filter_by_source=True
+        ):
             yield self.package(
-                id=package_id, name=name, installed_version=installed_version
+                id=package_id,
+                name=name,
+                installed_version=installed_version,
             )
 
     @property
@@ -146,26 +223,27 @@ class WinGet(PackageManager):
 
         .. code-block:: pwsh-session
 
-            PS C:\\Users\\kev> winget list --upgrade-available --accept-source-agreements --disable-interactivity
-            Name                          Id                           Version       Available     Source
-            ---------------------------------------------------------------------------------------------
-            Git                           Git.Git                      2.37.3        2.45.1        winget
-            Microsoft Edge                Microsoft.Edge               109.0.1518.70 125.0.2535.51 winget
-            Python Launcher               Python.Launchez              < 3.12.0      3.12.0        winget
-            Microsoft Visual C++ (x86)... Microsoft.VCRedist.2015+.X86 14.34.31931.0 14.38.33135.0 winget
-            4 upgrades available.
+            PS C:\\Users\\kev> winget list --upgrade-available --details --accept-source-agreements --disable-interactivity
+            (1/4) Git [Git.Git] Version: 2.37.3
+            Publisher: The Git Development Community
+            ...
+            Available Upgrades:
+              winget [2.45.1]
+
+            (2/4) Microsoft Edge [Microsoft.Edge] Version: 109.0.1518.70
+            Publisher: Microsoft
+            ...
+            Available Upgrades:
+              winget [125.0.2535.51]
+
+        Only returns packages with Origin Source: winget to exclude packages
+        installed via other sources (e.g., sideload, portable).
         """
-        output = self.run_cli("list", "--upgrade-available").strip()
-        if output.endswith(" upgrades available."):
-            output = "\n".join(output.splitlines()[:-1])
+        output = self.run_cli("list", "--upgrade-available", "--details")
 
-        for name, package_id, installed_version, latest_version, _ in self._parse_table(
-            output
+        for name, package_id, installed_version, latest_version in self._parse_details(
+            output, filter_by_source=True
         ):
-            # Strip the "<" comparison operator from the version.
-            if " " in installed_version:
-                installed_version = installed_version.split()[1]
-
             yield self.package(
                 id=package_id,
                 name=name,

--- a/meta_package_manager/managers/winget.py
+++ b/meta_package_manager/managers/winget.py
@@ -34,7 +34,7 @@ class WinGet(PackageManager):
 
     platforms = WINDOWS
 
-    requirement = ">=1.7"
+    requirement = ">=1.28.190"
 
     post_args = ("--accept-source-agreements", "--disable-interactivity")
     """
@@ -59,12 +59,12 @@ class WinGet(PackageManager):
         - https://github.com/microsoft/winget-cli/issues/3494#issuecomment-3921618377
     """
 
-    version_regexes = (r"v\s*(?P<version>\S+)",)
+    version_regexes = (r"v(?P<version>\S+)",)
     """
     .. code-block:: pwsh-session
 
         PS C:\\Users\\kev> winget --version
-        Windows Package Manager v1.28.220
+        v1.28.220
     """
 
     def _parse_details(

--- a/meta_package_manager/managers/winget.py
+++ b/meta_package_manager/managers/winget.py
@@ -67,77 +67,78 @@ class WinGet(PackageManager):
         v1.28.220
     """
 
+    # Header line pattern. The ``(N/M)`` prefix is present only when multiple
+    # packages are listed; a single result omits it.
+    _header_re = re.compile(
+        r"^(?:\(\d+/\d+\)\s+)?(.+)\s+\[([^\]]+)\]\s*$",
+    )
+
     def _parse_details(
         self, output: str, filter_by_source: bool = False
     ) -> Iterator[tuple[str, str, str, str | None]]:
-        """Parse --details output from winget list or upgrade-available commands.
+        """Parse ``--details`` output from ``winget list``.
 
-        Each package is formatted as:
+        Each package block starts with a header line and is followed by
+        ``Key: Value`` metadata lines:
+
+        .. code-block:: text
+
             (N/M) <Name> [<Id>]
-            Version: <current_version>
+            Version: <version>
             Publisher: <publisher>
             Origin Source: winget
-            ...
-            [Available Upgrades:]
-            [  winget [<latest_version>]]
+            Available Upgrades:
+              winget [<latest_version>]
 
-        If filter_by_source=True, only packages with Origin Source: winget are returned.
+        :param filter_by_source: If ``True``, only yield packages whose
+            ``Origin Source`` is ``winget``.
         """
-        # Split on block markers like "(1/232) Package Name [Id]"
-        blocks = re.split(r'(?=^\(\d+/\d+\) )', output, flags=re.MULTILINE)
+        # Split output into per-package blocks on the header line.
+        blocks = re.split(
+            r"(?=^(?:\(\d+/\d+\)\s+)?.+\[[^\]]+\]\s*$)",
+            output,
+            flags=re.MULTILINE,
+        )
 
         for block in blocks:
-            if not block.strip():
+            block = block.strip()
+            if not block:
                 continue
 
-            lines = block.strip().splitlines()
-            if not lines:
-                continue
-
-            # Parse the header line: (N/M) <Name> [<Id>]
-            header = lines[0]
-            header_match = re.match(
-                r'^\(\d+/\d+\)\s+(.+)\s+\[([^\]]+)\]$',
-                header,
-            )
+            lines = block.splitlines()
+            header_match = self._header_re.match(lines[0])
             if not header_match:
                 continue
 
             name = header_match.group(1).strip()
             package_id = header_match.group(2).strip()
-            version = None
-            origin_source = None
 
-            # Look for version on the next line or in key:value format
+            # Collect key:value fields from the remaining lines.
+            fields: dict[str, str] = {}
+            for line in lines[1:]:
+                if ":" in line:
+                    key, _, value = line.partition(":")
+                    fields[key.strip()] = value.strip()
+
+            version = fields.get("Version")
+            if not version:
+                continue
+
+            if filter_by_source and fields.get("Origin Source") != "winget":
+                continue
+
+            # Extract latest version from the "Available Upgrades" section.
+            # The upgrade line looks like ``  winget [1.2.3]``.
             latest_version = None
-            for i, line in enumerate(lines[1:], 1):
-                line_stripped = line.strip()
-                # Extract version from "Version: X.Y.Z" line
-                if line_stripped.startswith('Version:'):
-                    version = line_stripped.split(':', 1)[1].strip()
-                # Track Origin Source
-                elif line_stripped.startswith('Origin Source:'):
-                    origin_source = line_stripped.split(':', 1)[1].strip()
-                # Look for available upgrades
-                elif line_stripped == 'Available Upgrades:':
-                    # Next non-empty line should have the version.
-                    for future_line in lines[i + 1:]:
-                        future_line = future_line.strip()
-                        if future_line:
-                            # Format: "winget [X.Y.Z]"
-                            upgrade_match = re.search(r'\[([^\]]+)\]', future_line)
-                            if upgrade_match:
-                                latest_version = upgrade_match.group(1)
-                            break
-                    break
+            upgrade_match = re.search(
+                r"^Available Upgrades:\s*\n\s+\S+\s+\[([^\]]+)\]",
+                block,
+                flags=re.MULTILINE,
+            )
+            if upgrade_match:
+                latest_version = upgrade_match.group(1)
 
-            # Only yield if we found a version
-            if version:
-                # Filter by source if requested (only include winget packages)
-                if filter_by_source and origin_source != 'winget':
-                    continue
-
-                yield (name, package_id, version, latest_version)
+            yield name, package_id, version, latest_version
 
     def _parse_table(self, output: str) -> Iterator[Generator[str, None, None]]:
         """Parse a table from the output of a winget command and returns a generator of cells."""
@@ -188,7 +189,8 @@ class WinGet(PackageManager):
         .. code-block:: pwsh-session
 
             PS C:\\Users\\kev> winget list --details --accept-source-agreements --disable-interactivity
-            (1/7) CCleaner [CCleaner] Version: 6.08
+            (1/7) CCleaner [CCleaner]
+            Version: 6.08
             Publisher: Piriform Software Ltd
             Local Identifier: ARP\\Machine\\X64\\CCleaner
             Product Code: CCleaner
@@ -199,7 +201,8 @@ class WinGet(PackageManager):
             Origin Source: winget
             Available Upgrades:
 
-            (2/7) Git [Git.Git] Version: 2.37.3
+            (2/7) Git [Git.Git]
+            Version: 2.37.3
             Publisher: The Git Development Community
             ...
 
@@ -224,13 +227,15 @@ class WinGet(PackageManager):
         .. code-block:: pwsh-session
 
             PS C:\\Users\\kev> winget list --upgrade-available --details --accept-source-agreements --disable-interactivity
-            (1/4) Git [Git.Git] Version: 2.37.3
+            (1/4) Git [Git.Git]
+            Version: 2.37.3
             Publisher: The Git Development Community
             ...
             Available Upgrades:
               winget [2.45.1]
 
-            (2/4) Microsoft Edge [Microsoft.Edge] Version: 109.0.1518.70
+            (2/4) Microsoft Edge [Microsoft.Edge]
+            Version: 109.0.1518.70
             Publisher: Microsoft
             ...
             Available Upgrades:


### PR DESCRIPTION
### Motivation

Enhances package detection accuracy and reliability for the WinGet manager on Windows systems.

### Key Improvements

- Adds detection of Windows App Execution Aliases (reparse points), ensuring CLI discovery works for cases where executables are represented as reparse points rather than regular files.
- Refactors package listing and upgrade logic to parse the `--details` output format, allowing for more precise extraction of version, source, and upgrade information.
- Filters package queries to only include those installed via the official package source, avoiding interference from external or sideloaded installations.
- Updates version extraction to handle new output formats and edge cases.

### Benefits

- Increases compatibility with recent WinGet CLI changes.
- Improves accuracy of package status reporting and upgrade detection.
- Reduces the risk of false positives or missed packages on Windows.