### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-06T19:06:06.952151Z"
+exclude-newer = "2026-04-06T20:58:27.124521436Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -249,8 +249,8 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.11.0.dev0"
-source = { git = "https://github.com/kdeldycke/click-extra.git?branch=main#badc2abe3ce7a006a55c50f22053dd77068ab89a" }
+version = "7.11.1.dev0"
+source = { git = "https://github.com/kdeldycke/click-extra.git?branch=main#733f400c0aa2f7fdaebe6a6f096d04abffe97f54" }
 dependencies = [
     { name = "boltons" },
     { name = "click" },


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-06`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `7.11.0.dev0` -> `7.11.1.dev0` |  |

### Release notes

<details>
<summary>kdeldycke/click-extra (<code>click-extra</code>)</summary>

[Changelog](https://redirect.github.com/kdeldycke/click-extra/blob/main/changelog.md)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`5214199e`](https://github.com/kdeldycke/meta-package-manager/commit/5214199e742298397f8924d9e7df267cccd2111b) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/5214199e742298397f8924d9e7df267cccd2111b/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/5214199e742298397f8924d9e7df267cccd2111b/.github/workflows/autofix.yaml) |
| **Run** | [#2756.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/24364503939) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.12.0`