### PR TITLE
Fix winget search to handle no results gracefully

### DIFF
--- a/meta_package_manager/managers/winget.py
+++ b/meta_package_manager/managers/winget.py
@@ -144,9 +144,8 @@ class WinGet(PackageManager):
         """Parse a table from the output of a winget command and returns a generator of cells."""
         # Extract table.
         table_start = "Name "
-        assert table_start in output, (
-            f"Cannot find table starting with {table_start!r} in:\n{output}"
-        )
+        if table_start not in output:
+            return
         assert output.count(table_start) == 1, (
             f"{table_start!r} not unique in:\n{output}"
         )


### PR DESCRIPTION
Ensure the winget search function gracefully handles cases with no results by checking the output before parsing.

This will avoid an assert dump if no search results are found.  I chose to handle before trying to parse the table instead of breaking the table asserts.

```shell-session
mpm search badbadbadbad

info: User selection of managers by priority: platform default
info: Managers dropped by user: None
info: Skip unavailable cargo manager.
info: Skip unavailable choco manager.
info: Skip unavailable composer manager.
warning: cpan does not implement Operations.search.
info: Skip unavailable gem manager.
warning: pip does not implement Operations.search.
warning: pipx does not implement Operations.search.
warning: steamcmd does not implement Operations.search.
warning: stew does not implement Operations.search.
warning: uv does not implement Operations.search.
warning: uvx does not implement Operations.search.
warning: vscode does not implement Operations.search.
warning: vscodium does not implement Operations.search.
```
```pytb
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\...\.local\bin\mpm.exe\__main__.py", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "C:\Users\...\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\meta_package_manager\__main__.py", line 45, in main
    mpm(prog_name=mpm.name)
    ~~~^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\WayneArthurton\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\click\core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "C:\Users\WayneArthurton\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\click_extra\commands.py", line 410, in main
    return super().main(args=args, prog_name=prog_name, **kwargs)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\...\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\click\core.py", line 1406, in main
    rv = self.invoke(ctx)
  File "C:\Users\...\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\click_extra\commands.py", line 766, in invoke
    return super().invoke(ctx)
           ~~~~~~~~~~~~~~^^^^^
  File "C:\Users\WayneArthurton\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\click_extra\commands.py", line 450, in invoke
    return super().invoke(ctx)
           ~~~~~~~~~~~~~~^^^^^
  File "C:\Users\...\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\click\core.py", line 1873, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "C:\Users\...\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\click_extra\commands.py", line 450, in invoke
    return super().invoke(ctx)
           ~~~~~~~~~~~~~~^^^^^
  File "C:\Users\...\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\click\core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\WayneArthurton\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\click\core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "C:\Users\...\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\cloup\_context.py", line 47, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "C:\Users\...\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\meta_package_manager\cli.py", line 838, in search
    packages = tuple(
        packages_asdict(
    ...<2 lines>...
        ),
    )
  File "C:\Users\...\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\meta_package_manager\base.py", line 172, in <genexpr>
    return ({k: v for k, v in asdict(p).items() if k in keep_fields} for p in packages)
                                                                              ^^^^^^^^
  File "C:\Users\...\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\meta_package_manager\base.py", line 1025, in refiltered_search
    for match in self.search(query, extended, exact):
                 ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\WayneArthurton\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\meta_package_manager\managers\winget.py", line 343, in search
    for name, package_id, version, _ in self._parse_table(output):
                                        ~~~~~~~~~~~~~~~~~^^^^^^^^
  File "C:\Users\...\AppData\Roaming\uv\tools\meta-package-manager\Lib\site-packages\meta_package_manager\managers\winget.py", line 147, in _parse_table
    assert table_start in output, (
           ^^^^^^^^^^^^^^^^^^^^^
AssertionError: Cannot find table starting with 'Name ' in:
-
   \
   |
   /

No package found matching input criteria.