### PR TITLE
Format Python

### DIFF
--- a/.claude/skills/add-manager/SKILL.md
+++ b/.claude/skills/add-manager/SKILL.md
@@ -96,6 +96,7 @@ When a manager uses its own CLI for read operations but delegates mutating opera
 from ..capabilities import Delegate
 from .scoop import Scoop
 
+
 class SFSU(PackageManager):
     _scoop = Delegate(Scoop)
 

--- a/meta_package_manager/capabilities.py
+++ b/meta_package_manager/capabilities.py
@@ -109,8 +109,7 @@ class DelegatedMethod:
         def wrapper(*args, **kwargs):
             cli_path = obj.which(cli_name)
             logging.debug(
-                f"Delegating {obj.id}.{self.attr_name} to {cli_name} "
-                f"at {cli_path}.",
+                f"Delegating {obj.id}.{self.attr_name} to {cli_name} at {cli_path}.",
             )
             obj._delegate_cli_path = cli_path  # type: ignore[attr-defined]
             try:


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`b667d798`](https://github.com/kdeldycke/meta-package-manager/commit/b667d798bc33f65f5ac759666bb88a0290ff5b00) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/b667d798bc33f65f5ac759666bb88a0290ff5b00/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/b667d798bc33f65f5ac759666bb88a0290ff5b00/.github/workflows/autofix.yaml) |
| **Run** | [#2784.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/24670083012) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`