### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/managers/macports.py
+++ b/meta_package_manager/managers/macports.py
@@ -105,9 +105,11 @@ class MacPorts(PackageManager):
         """
         output = self.run_cli("-q", "outdated")
 
-        for package_id, installed_version, latest_version in (
-            self._OUTDATED_REGEXP.findall(output)
-        ):
+        for (
+            package_id,
+            installed_version,
+            latest_version,
+        ) in self._OUTDATED_REGEXP.findall(output):
             yield self.package(
                 id=package_id,
                 installed_version=installed_version,


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`b02b92e1`](https://github.com/kdeldycke/meta-package-manager/commit/b02b92e10deb1a1a1047d9d0936fcf05b0b1e3fd) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/b02b92e10deb1a1a1047d9d0936fcf05b0b1e3fd/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/b02b92e10deb1a1a1047d9d0936fcf05b0b1e3fd/.github/workflows/autofix.yaml) |
| **Run** | [#2803.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/24773915680) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0`