### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -8,11 +8,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-15T12:06:32.082022425Z"
+exclude-newer = "2026-04-15T12:45:19.708299898Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-lxml = { timestamp = "2026-04-22T12:06:32.080521213Z", span = "PT0S" }
+lxml = { timestamp = "2026-04-22T12:45:19.708308544Z", span = "PT0S" }
 
 [[package]]
 name = "accessible-pygments"
@@ -1169,11 +1169,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-15`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [packaging](https://pypi.org/project/packaging/) | [`26.0` → `26.1`](https://github.com/pypa/packaging/compare/26.0...26.1) | 2026-04-14 |

### Release notes

<details>
<summary><code>packaging</code></summary>

#### [`26.1`](https://github.com/pypa/packaging/releases/tag/26.1)

Features:

* ~~PEP 783: add handling for Emscripten wheel tags by @​hoodmane in https://redirect.github.com/pypa/packaging/pull/804~~ (old name used in implementation, will be fixed in next release)
* PEP 803: add handling for the `abi3.abi3t` free-threading tag by @​ngoldbaum in https://redirect.github.com/pypa/packaging/pull/1099
* PEP 723: add `packaging.dependency_groups` module, based on the `dependency-groups` package by @​sirosen in https://redirect.github.com/pypa/packaging/pull/1065
* Add the `packaging.direct_url` module by @​sbidoul in https://redirect.github.com/pypa/packaging/pull/944
* Add the `packaging.errors` module by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1071
* Add `SpecifierSet.is_unsatisfiable` using ranges (new internals that will be expanded in future versions) by @​notatallshaw in https://redirect.github.com/pypa/packaging/pull/1119
* Add `create_compatible_tags_selector` to select compatible tags by @​sbidoul in https://redirect.github.com/pypa/packaging/pull/1110
* Add a `key` argument to `SpecifierSet.filter()` by @​frostming in https://redirect.github.com/pypa/packaging/pull/1068
* Support `&` and `|` for `Marker`'s by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1146
* Normalize `Version.__replace__` and add `Version.from_parts` by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1078
* Add an option to validate compressed tag set sort order in `parse_wheel_filename` by @​r266-tech in https://redirect.github.com/pypa/packaging/pull/1150

Behavior adaptations:

* Narrow exclusion of pre-releases for `<V.postN` to match spec by @​notatallshaw in https://redirect.github.com/pypa/packaging/pull/1140
* Narrow exclusion of post-releases for `>V` to match spec by @​notatallshaw in https://redirect.github.com/pypa/packaging/pull/1141

... [Full release notes](https://github.com/pypa/packaging/releases/tag/26.1)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`175cb181`](https://github.com/kdeldycke/meta-package-manager/commit/175cb1818ea7191de5e834812dec941699672517) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/175cb1818ea7191de5e834812dec941699672517/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/175cb1818ea7191de5e834812dec941699672517/.github/workflows/autofix.yaml) |
| **Run** | [#2806.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/24778768405) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0`