### PR TITLE
Fix header parsing and enhance Microsoft Store package handling

### DIFF
--- a/meta_package_manager/managers/winget.py
+++ b/meta_package_manager/managers/winget.py
@@ -67,6 +67,10 @@ class WinGet(PackageManager):
         v1.28.220
     """
 
+    # Microsoft Store IDs are either 12-char product IDs or 14-char extension
+    # IDs prefixed with ``XP`` (like ``XP99BNH2JZBBQR``).
+    _store_id_re = re.compile(r"^(?:[0-9A-Z]{12}|XP[0-9A-Z]{12})$")
+
     # Header line pattern. The ``(N/M)`` prefix is present only when multiple
     # packages are listed; a single result omits it.
     _header_re = re.compile(
@@ -94,8 +98,11 @@ class WinGet(PackageManager):
             ``Origin Source`` is ``winget``.
         """
         # Split output into per-package blocks on the header line.
+        # The \S anchor after the optional (N/M) prefix prevents the split from
+        # firing on indented upgrade lines like ``  winget [1.2.3]``, which also
+        # end with a bracketed token but are not package headers.
         blocks = re.split(
-            r"(?=^(?:\(\d+/\d+\)\s+)?.+\[[^\]]+\]\s*$)",
+            r"(?=^(?:\(\d+/\d+\)\s+)?\S.+\[[^\]]+\]\s*$)",
             output,
             flags=re.MULTILINE,
         )
@@ -149,14 +156,17 @@ class WinGet(PackageManager):
         assert output.count(table_start) == 1, (
             f"{table_start!r} not unique in:\n{output}"
         )
-        table = output.split(table_start, 1)[1]
+        table = output[output.index(table_start):]
 
         # Check table format.
         lines = table.splitlines()
-        table_width = len(lines[0])
-        assert lines[1] == "-" * table_width, (
+        assert re.match(r"^-+$", lines[1]), (
             f"Table headers not followed by expected separator:\n{table}"
         )
+        # Use the separator line as the authoritative table width; winget may
+        # omit trailing spaces from the header line, making it one character
+        # shorter than the dashes.
+        table_width = len(lines[1])
         assert all(len(line) <= table_width for line in lines[2:]), (
             f"Table lines with different width:\n{table}"
         )
@@ -180,6 +190,18 @@ class WinGet(PackageManager):
 
         for line in lines[2:]:
             yield (line[start:end].strip() for start, end in col_ranges)
+
+    def _build_package(self, name: str, package_id: str, version: str) -> Package:
+        """Build a :class:`Package` from a search result row.
+
+        Microsoft Store packages have their ``latest_version`` set to the
+        ``msstore`` sentinel because their real version cannot be queried via
+        ``winget``. The sentinel is later used by :meth:`search` to push Store
+        results below winget-native ones.
+        """
+        if self._store_id_re.match(package_id):
+            return self.package(id=package_id, name=name, latest_version="msstore")
+        return self.package(id=package_id, name=name, latest_version=version)
 
     @property
     def installed(self) -> Iterator[Package]:
@@ -322,6 +344,8 @@ class WinGet(PackageManager):
             --------------------------------------------
             Codium Alex313031.Codium 1.86.2.24053 winget
         """
+        results: list[Package] = []
+
         # Default search is extended to all metadata: id, name, moniker and tag.
         if extended:
             args = ["search", "--query", query]
@@ -330,7 +354,7 @@ class WinGet(PackageManager):
                 args.append("--exact")
             output = self.run_cli(args)
             for name, package_id, version, _, _ in self._parse_table(output):
-                yield self.package(id=package_id, name=name, latest_version=version)
+                results.append(self._build_package(name, package_id, version))
 
         # For non-extended search, we need to perform 2 queries, one for id and
         # one for name.
@@ -340,7 +364,10 @@ class WinGet(PackageManager):
                     "search", field, query, "--exact" if exact else None
                 )
                 for name, package_id, version, _ in self._parse_table(output):
-                    yield self.package(id=package_id, name=name, latest_version=version)
+                    results.append(self._build_package(name, package_id, version))
+
+        # Yield winget-native packages first, Microsoft Store packages last.
+        yield from sorted(results, key=lambda p: bool(self._store_id_re.match(p.id)))
 
     def install(self, package_id: str, version: str | None = None) -> str:
         """Install one package.

--- a/tests/test_manager_winget.py
+++ b/tests/test_manager_winget.py
@@ -1,0 +1,178 @@
+# Copyright Kevin Deldycke <kevin@deldycke.com> and contributors.
+#
+# This program is Free Software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+"""WinGet-specific parsing tests.
+
+These tests cover the pure-Python parsing/regex logic. They do not invoke
+``winget.exe`` and are platform-agnostic.
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from meta_package_manager.managers.winget import WinGet
+
+
+@pytest.fixture
+def winget():
+    return WinGet()
+
+
+@pytest.mark.parametrize(
+    "package_id",
+    (
+        # 12-char product IDs.
+        "9PF4QZKKRZ7N",
+        "9NBLGGH4NNS1",
+        "9MZ1SNWT0N5D",
+        # 14-char extension IDs.
+        "XP99BNH2JZBBQR",
+        "XP8K0HKJFRXGCK",
+    ),
+)
+def test_store_id_re_matches(package_id):
+    assert WinGet._store_id_re.match(package_id)
+
+
+@pytest.mark.parametrize(
+    "package_id",
+    (
+        # Native winget IDs are dotted, mixed-case identifiers.
+        "Microsoft.PowerToys",
+        "Mozilla.Firefox",
+        "Alex313031.Codium",
+        "VSCodium.VSCodium",
+        # Lowercase 12-char string is not a Store ID.
+        "abcdefghijkl",
+        # Wrong length: 11 and 13 chars.
+        "9PF4QZKKRZ7",
+        "9PF4QZKKRZ7NN",
+        # ``XP``-prefixed but wrong length (not 12 or 14 chars total).
+        "XP123456789012345",
+        # Empty.
+        "",
+    ),
+)
+def test_store_id_re_rejects(package_id):
+    assert WinGet._store_id_re.match(package_id) is None
+
+
+def test_parse_details_ignores_indented_upgrade_line(winget):
+    """Regression test: the package-block split must not fire on indented
+    ``  winget [version]`` lines under ``Available Upgrades``."""
+    output = dedent("""\
+        (1/1) Git [Git.Git]
+        Version: 2.37.3
+        Publisher: The Git Development Community
+        Origin Source: winget
+        Available Upgrades:
+          winget [2.45.1]
+        """)
+
+    blocks = list(winget._parse_details(output))
+    assert len(blocks) == 1
+    name, package_id, version, latest_version = blocks[0]
+    assert name == "Git"
+    assert package_id == "Git.Git"
+    assert version == "2.37.3"
+    assert latest_version == "2.45.1"
+
+
+def test_parse_details_filter_by_source(winget):
+    output = dedent("""\
+        (1/2) Git [Git.Git]
+        Version: 2.37.3
+        Origin Source: winget
+
+        (2/2) Some Store App [9PF4QZKKRZ7N]
+        Version: Unknown
+        Origin Source: msstore
+        """)
+
+    all_blocks = list(winget._parse_details(output))
+    winget_only = list(winget._parse_details(output, filter_by_source=True))
+    assert len(all_blocks) == 2
+    assert len(winget_only) == 1
+    assert winget_only[0][1] == "Git.Git"
+
+
+def test_parse_table_handles_short_header_line(winget):
+    """Regression test: winget may emit a header line shorter than the
+    separator (trailing spaces on the last column are trimmed). The separator
+    must drive the column width so data rows that fill the full width do not
+    trip the width assertion."""
+    # Build a table where the header line is intentionally one char shorter
+    # than the separator (last column lacks a trailing space) but data rows
+    # match the separator length. Pre-fix code computed
+    # ``table_width = len(lines[0])`` and tripped the
+    # ``len(line) <= table_width`` assertion on the data row.
+    header = "Name              Id                Version      Source"
+    data = "VSCodium          VSCodium.VSCodium 1.89.1.24130 winget "
+    separator = "-" * len(data)
+    assert len(header) < len(separator), "fixture sanity check"
+
+    output = f"{header}\n{separator}\n{data}\n"
+    rows = [list(row) for row in winget._parse_table(output)]
+    assert len(rows) == 1
+    assert rows[0][0] == "VSCodium"
+    assert rows[0][1] == "VSCodium.VSCodium"
+
+
+def test_parse_table_yields_nothing_on_empty_output(winget):
+    assert list(winget._parse_table("")) == []
+
+
+def test_build_package_native(winget):
+    pkg = winget._build_package("Codium", "Alex313031.Codium", "1.86.2.24053")
+    assert pkg.id == "Alex313031.Codium"
+    assert pkg.name == "Codium"
+    assert str(pkg.latest_version) == "1.86.2.24053"
+
+
+@pytest.mark.parametrize(
+    "package_id",
+    ("9PF4QZKKRZ7N", "XP99BNH2JZBBQR"),
+)
+def test_build_package_store_uses_msstore_sentinel(winget, package_id):
+    pkg = winget._build_package("Some App", package_id, "1.0.0")
+    assert pkg.id == package_id
+    assert str(pkg.latest_version) == "msstore"
+
+
+def test_search_orders_native_before_store(winget, monkeypatch):
+    """Microsoft Store entries must come after winget-native ones in the search
+    output, regardless of the order winget returned them in."""
+    rows = [
+        "Store App         XP99BNH2JZBBQR    1.0.0        Tag: vscode     msstore",
+        "Codium            Alex313031.Codium 1.86.0       Tag: vscode     winget ",
+        "Other             9PF4QZKKRZ7N      2.0.0        Tag: vscode     msstore",
+    ]
+    width = max(len(row) for row in rows)
+    header = "Name              Id                Version      Match           Source"
+    table = "\n".join([header, "-" * width, *rows]) + "\n"
+
+    monkeypatch.setattr(winget, "run_cli", lambda *a, **kw: table)
+
+    results = list(winget.search("vscode", extended=True, exact=False))
+    ids = [p.id for p in results]
+    # Native package first, Store packages last. ``sorted`` is stable so the
+    # relative order within each group matches the input.
+    assert ids == ["Alex313031.Codium", "XP99BNH2JZBBQR", "9PF4QZKKRZ7N"]
+    assert str(results[0].latest_version) == "1.86.0"
+    assert str(results[1].latest_version) == "msstore"
+    assert str(results[2].latest_version) == "msstore"


### PR DESCRIPTION

This pull request improves the robustness and accuracy of Microsoft Store package detection and parsing logic in the `WinGet` package manager integration. The main changes focus on correctly identifying Microsoft Store packages, handling table parsing more reliably, and ensuring that search results are ordered with native packages before Store packages.

**Microsoft Store package detection and search result ordering:**

* Added a regular expression (`_store_id_re`) to accurately identify Microsoft Store IDs, supporting both 12-character product IDs and 14-character extension IDs prefixed with `XP`.
* Refactored the `search` method to use the new `_store_id_re` for detecting Store packages, setting their `latest_version` to `"msstore"`

**Parsing and table handling improvements:**

* Improved the regular expression in `_parse_details` to prevent splitting on indented upgrade lines, ensuring more accurate parsing of package blocks.
* Enhanced the `_parse_table` method to use the separator line as the authoritative table width and to tolerate minor inconsistencies in table formatting, improving robustness against output variations from `winget`.