### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -237,14 +237,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-22`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click](https://pypi.org/project/click/) | [`8.3.2` → `8.3.3`](https://github.com/pallets/click/compare/8.3.2...8.3.3) | 2026-04-22 |

### Release notes

<details>
<summary><code>click</code></summary>

#### [`8.3.3`](https://github.com/pallets/click/releases/tag/8.3.3)

This is the Click 8.3.3 fix release, which fixes bugs but does not otherwise change behavior and should not result in breaking changes compared to the latest feature release.

PyPI: https://pypi.org/project/click/8.3.3/
Changes: https://click.palletsprojects.com/page/changes/#version-8-3-3
Milestone: https://redirect.github.com/pallets/click/milestone/30

-   Use :func:`shlex.split` to split pager and editor commands into ``argv``
    lists for :class:`subprocess.Popen`, removing ``shell=True``.
    #​1026 #​1477 #​2775
-   Fix ``TypeError`` when rendering help for an option whose default value is
    an object that doesn't support equality comparison with strings, such as
    ``semver.Version``. #​3298 #​3299
-   Fix pager test pollution under parallel execution by using pytest's
    ``tmp_path`` fixture instead of a shared temporary file path. #​3238
-   Treat ``Sentinel.UNSET`` values in a ``default_map`` as absent, so they fall
    through to the next default source instead of being used as the value.
    #​3224 #​3240
-   Patch ``pdb.Pdb`` in ``CliRunner`` isolation so ``pdb.set_trace()``,
    ``breakpoint()``, and debuggers subclassing ``pdb.Pdb`` (ipdb, pdbpp) can
    interact with the real terminal instead of the captured I/O streams.
    #​654 #​824 #​843 #​951 #​3235
-   Add optional randomized parallel test execution using ``pytest-randomly`` and
    ``pytest-xdist`` to detect test pollution and race conditions. #​3151
-   Add contributor documentation for running stress tests, randomized
    parallel tests, and Flask smoke tests. #​3151 #​3177
-   Show custom ``show_default`` string in prompts, matching the existing
    help text behavior. #​2836 #​2837 #​3165 #​3262 #​3280
    #​3328
-   Fix ``default=True`` with boolean ``flag_value`` always returning the
    ``flag_value`` instead of ``True``. The ``default=True`` to ``flag_value``
    substitution now only applies to non-boolean flags, where ``True`` acts as a

... [Full release notes](https://github.com/pallets/click/releases/tag/8.3.3)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`50424eaf`](https://github.com/kdeldycke/meta-package-manager/commit/50424eaf62a4681382ce26f257d69b1b617c78e3) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/50424eaf62a4681382ce26f257d69b1b617c78e3/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/50424eaf62a4681382ce26f257d69b1b617c78e3/.github/workflows/autofix.yaml) |
| **Run** | [#2860.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25112010425) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0`