### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/managers/winget.py
+++ b/meta_package_manager/managers/winget.py
@@ -156,7 +156,7 @@ class WinGet(PackageManager):
         assert output.count(table_start) == 1, (
             f"{table_start!r} not unique in:\n{output}"
         )
-        table = output[output.index(table_start):]
+        table = output[output.index(table_start) :]
 
         # Check table format.
         lines = table.splitlines()


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`50424eaf`](https://github.com/kdeldycke/meta-package-manager/commit/50424eaf62a4681382ce26f257d69b1b617c78e3) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/50424eaf62a4681382ce26f257d69b1b617c78e3/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/50424eaf62a4681382ce26f257d69b1b617c78e3/.github/workflows/autofix.yaml) |
| **Run** | [#2860.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25112010425) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0`