### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -530,11 +530,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "11.1.0"
+version = "12.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/7b/0049f8a7817ac4eb6ad1af72c7938fff3e2677d55468c87de792208e068c/extra_platforms-11.1.0.tar.gz", hash = "sha256:3045d722cab2b422a8fcbcba7f52026c33523cb147616d99fc50947f8e952375", size = 69265, upload-time = "2026-04-21T08:28:21.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3e/b7dfcbd8ccfb8127f2b907e3c7eabf0ff34bebdc7ae126266fbb7eba7208/extra_platforms-12.0.1.tar.gz", hash = "sha256:55146246c1e4babe385d2438c4da54e3f0078cedc70914288bedbe6502849218", size = 72199, upload-time = "2026-04-26T21:06:51.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/75/5985d4b10248cc03f5d0ef03026f3cc69a427baa77b6b07fe26a674bba1a/extra_platforms-11.1.0-py3-none-any.whl", hash = "sha256:5d4476774e5d639813060c239b40481a714f785515db66bcbb19a7b3881debc1", size = 72560, upload-time = "2026-04-21T08:28:20.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dc/b61a087ba06eb0a53ebf8d3d51b901e84993a6e0138537d3239f15a82f3c/extra_platforms-12.0.1-py3-none-any.whl", hash = "sha256:e5df76a229c518fe5d12a049d6e54457b2f64bd1c440b185c60256f816b4d747", size = 75447, upload-time = "2026-04-26T21:06:49.757Z" },
 ]
 
 [[package]]
@@ -575,11 +575,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.12"
+version = "3.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254", size = 194350, upload-time = "2026-04-21T13:32:48.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67", size = 68634, upload-time = "2026-04-21T13:32:47.403Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -1157,11 +1157,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -2098,11 +2098,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2026.1"
+version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]
@@ -2116,11 +2116,11 @@ wheels = [
 
 [[package]]
 name = "uritools"
-version = "6.0.1"
+version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/f7/6651d145bedd535a5bdd6dad108329ec1fec89d38ec611f8d98834eb5378/uritools-6.0.1.tar.gz", hash = "sha256:2f9e9cb954e7877232b2c863f724a44a06eb98d9c7ebdd69914876e9487b94f8", size = 22857, upload-time = "2025-12-21T18:58:54.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/92/07bd0999768dc45ab2be5795d53065cabee3bd54db89e7499005e09a4a32/uritools-6.0.2.tar.gz", hash = "sha256:4d671c3b8ca230a5d47efa5f8a693f3d01531f38f4f523170299be734cc9851b", size = 23199, upload-time = "2026-04-22T20:17:08.26Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/d7/e1542857c3f7615a1a9afa6b602b87cb5a33885db41c686aa7bf5092d4f0/uritools-6.0.1-py3-none-any.whl", hash = "sha256:d9507b82206c857d2f93d8fcc84f3b05ae4174096761102be690aa76a360cc1b", size = 10466, upload-time = "2025-12-21T18:58:52.903Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/85/89de28a9c7c94733e6525a39960f23bf557c1e072b1c53f787b6e5279ff1/uritools-6.0.2-py3-none-any.whl", hash = "sha256:6c1bc9a38810f38d5e6b2ea0eb3edb6c3311bd915a4d4f457ff0de565d0e614b", size = 10636, upload-time = "2026-04-22T20:17:06.719Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-27`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`11.1.0` → `12.0.1`](https://github.com/kdeldycke/extra-platforms/compare/v11.1.0...v12.0.1) | 2026-04-26 |
| [idna](https://pypi.org/project/idna/) | [`3.12` → `3.13`](https://github.com/kjd/idna/compare/v3.12...v3.13) | 2026-04-22 |
| [packaging](https://pypi.org/project/packaging/) | [`26.1` → `26.2`](https://github.com/pypa/packaging/compare/26.1...26.2) | 2026-04-24 |
| [tzdata](https://pypi.org/project/tzdata/) | [`2026.1` → `2026.2`](https://github.com/python/tzdata/compare/2026.1...2026.2) | 2026-04-24 |
| [uritools](https://pypi.org/project/uritools/) | [`6.0.1` → `6.0.2`](https://github.com/tkem/uritools/compare/v6.0.1...v6.0.2) | 2026-04-22 |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v12.0.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v12.0.0)

> [!NOTE]
> `12.0.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/12.0.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v12.0.0).

- Add `SH` (Bourne Shell) trait and `is_sh()` detection function.
- Add `GUIX_BUILD` CI trait and `is_guix_build()` detection function.
- Add `--json`, `--version`, and `--help` options to the CLI. `--json` outputs all detected traits and groups as a JSON object for scripting.
- Overhaul shell detection: resolve symlinks in `SHELL` before identifying the implementation (so `/bin/sh` → `/bin/bash` detects bash, not sh); `current_shell()` now disambiguates via three-tier priority — startup env vars, then `/proc` parent process tree, then `SHELL` value — fixing detection on CI runners where `SHELL=/bin/sh` points to a different shell than the one actually executing; `SH` is treated as a low-specificity fallback and stripped when a more specific shell is detected; new `version_env_var` field on `Shell` records each shell's startup environment variable (like `BASH_VERSION` for Bash); `is_powershell()` now checks `PSModulePath` as a presence signal rather than a version variable. Use `is_bourne_shells()` to check for a Bourne-compatible interface regardless of implementation.

**Full changelog**: [`v11.1.0...v12.0.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v11.1.0...v12.0.0)

#### [`v12.0.1`](https://github.com/kdeldycke/extra-platforms/releases/tag/v12.0.1)

> [!NOTE]
> `12.0.1` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/12.0.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v12.0.1).

- Defer `logging` and `warnings` imports out of the cold-load path: the stdlib `logging` import pulls in `traceback` (and `_colorize` on Python 3.14+), which dominates import time on slow architectures like i586. Closes {issue}`494`
- Loosen the `test_import_time` threshold from 500 ms to 1000 ms as a safety margin for slower architectures.

**Full changelog**: [`v12.0.0...v12.0.1`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v12.0.0...v12.0.1)

</details>

<details>
<summary><code>idna</code></summary>

[Changelog](https://redirect.github.com/kjd/idna/blob/master/HISTORY.rst)

</details>

<details>
<summary><code>packaging</code></summary>

#### [`26.2`](https://github.com/pypa/packaging/releases/tag/26.2)

## What's Changed

Fixes:

* Fix incorrect sysconfig var name for pyemscripten by @​ryanking13 in https://redirect.github.com/pypa/packaging/pull/1160
* Make `Version`, `Specifier`, `SpecifierSet`, `Tag`, `Marker`, and `Requirement` pickle-safe
  and backward-compatible with pickles created in 25.0-26.1 (including references to the removed
  ``packaging._structures`` module) by @​eachimei and @​henryiii in https://redirect.github.com/pypa/packaging/pull/1163, https://redirect.github.com/pypa/packaging/pull/1168, https://redirect.github.com/pypa/packaging/pull/1170, and https://redirect.github.com/pypa/packaging/pull/1171
* fix: re-export ExceptionGroup for now by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1164

Documentation:

* docs: add errors section and fix missing details by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1159
* docs(dev): document property-based test suite by @​r266-tech in https://redirect.github.com/pypa/packaging/pull/1167
* Fix typo in DirectUrl documentation by @​sbidoul in https://redirect.github.com/pypa/packaging/pull/1169
* docs(specifiers): add is_unsatisfiable() usage example by @​r266-tech in https://redirect.github.com/pypa/packaging/pull/1166

Internal:

* Enable the auditor persona on zizmor by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1158
* Test new pickle guarantees by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1174
* Use native uv integration in rtd by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1175



## New Contributors
* @​ryanking13 made their first contribution in https://redirect.github.com/pypa/packaging/pull/1160
* @​eachimei made their first contribution in https://redirect.github.com/pypa/packaging/pull/1163

**Full Changelog**: https://redirect.github.com/pypa/packaging/compare/26.1...26.2

</details>

<details>
<summary><code>tzdata</code></summary>

#### [`2026.2`](https://github.com/python/tzdata/releases/tag/2026.2)

# Version 2026.2

Upstream version 2026b released 2026-04-23T06:06:43+00:00

## Briefly:

British Columbia moved to permanent -07 on 2026-03-09. Some more overflow bugs
have been fixed in zic.

## Changes to future timestamps

British Columbia’s 2026-03-08 spring forward was its last foreseeable clock
change, as it moved to permanent -07 thereafter. (Thanks to Arthur David Olson.)
Although the change to permanent -07 legally took place on 2026-03-09,
temporarily model the change to occur on 2026-11-01 at 02:00 instead.  This
works around a limitation in CLDR v48.2 (2026-03-17).  This temporary hack is
planned to be removed after CLDR is fixed.

</details>

<details>
<summary><code>uritools</code></summary>

[Changelog](https://redirect.github.com/tkem/uritools/blob/master/CHANGELOG.rst)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`557f3171`](https://github.com/kdeldycke/meta-package-manager/commit/557f31716dd30e9754604e9e7c67090b564887d0) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/557f31716dd30e9754604e9e7c67090b564887d0/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/557f31716dd30e9754604e9e7c67090b564887d0/.github/workflows/autofix.yaml) |
| **Run** | [#2866.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25310680755) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.17.0`