### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/base.py
+++ b/meta_package_manager/base.py
@@ -33,9 +33,9 @@ from unittest.mock import patch
 
 from boltons.iterutils import unique
 from boltons.strutils import strip_ansi
-from click_extra.theme import default_theme as theme
 from click_extra.envvar import env_copy
 from click_extra.testing import INDENT, args_cleanup, format_cli_prompt
+from click_extra.theme import default_theme as theme
 from extra_platforms import (
     UNIX,
     Group,

--- a/meta_package_manager/cli.py
+++ b/meta_package_manager/cli.py
@@ -48,12 +48,12 @@ from click_extra import (
     pass_context,
 )
 from click_extra.colorize import HelpKeywords, highlight
-from click_extra.theme import KO, OK, default_theme as theme
 from click_extra.table import (
     SERIALIZATION_FORMATS,
     print_data,
     print_sorted_table,
 )
+from click_extra.theme import KO, OK, default_theme as theme
 from extra_platforms import reduce
 
 from . import __version__, bar_plugin

--- a/meta_package_manager/output.py
+++ b/meta_package_manager/output.py
@@ -28,8 +28,8 @@ from unittest.mock import patch
 
 from boltons.iterutils import flatten
 from click_extra import echo
-from click_extra.theme import default_theme as theme
 from click_extra.table import TableFormat, render_table
+from click_extra.theme import default_theme as theme
 
 from .bar_plugin import MPMPlugin
 from .pool import pool

--- a/meta_package_manager/pool.py
+++ b/meta_package_manager/pool.py
@@ -288,8 +288,7 @@ class ManagerPool:
             if drop_not_found and not manager.available:
                 reason = manager.unavailable_reason or "unavailable"
                 logging.info(
-                    f"Skip {theme.invoked_command(manager_id)} manager: "
-                    f"{reason}.",
+                    f"Skip {theme.invoked_command(manager_id)} manager: {reason}.",
                 )
                 continue
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`557f3171`](https://github.com/kdeldycke/meta-package-manager/commit/557f31716dd30e9754604e9e7c67090b564887d0) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/557f31716dd30e9754604e9e7c67090b564887d0/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/557f31716dd30e9754604e9e7c67090b564887d0/.github/workflows/autofix.yaml) |
| **Run** | [#2866.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25310680755) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.17.0`