### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@
 
 ## [`6.4.1` (2026-05-04)](https://github.com/kdeldycke/meta-package-manager/compare/v6.4.0...v6.4.1)
 
+> [!NOTE]
+> `6.4.1` is available on [🐍 PyPI](https://pypi.org/project/meta-package-manager/6.4.1/) and [🐙 GitHub](https://github.com/kdeldycke/meta-package-manager/releases/tag/v6.4.1).
+
 - [guix] Drop the `>=1.0.0` version requirement and add a hex-hash regex variant. Guix is a rolling-release distribution: `guix pull`-managed installs and in-tree dev wrappers (`./pre-inst-env guix`, `./scripts/guix`) report a git commit hash as the "version", which the previous `>=1.0.0` specifier rejected as not satisfying the requirement and made `mpm` skip the manager. The new `version_regexes` chain accepts stable releases (`1.4.0`), `git describe`-style versions (`1.4.0-7-gabc1234`), and bare 7–40-char lowercase hex hashes, so any working `guix` registers as available.
 - [mpm] Add `PackageManager.unavailable_reason` and use it in the pool's "Skip" log line. When `mpm` drops a manager from selection, the message now spells out *why* it was dropped: `not supported on '<sysname>'`, `no executable named '<names>' found in PATH`, `'<path>' is not executable`, `could not parse version from '<path>' output`, or `version <X> does not satisfy '<spec>' requirement`. Replaces the previous opaque `Skip unavailable <id> manager.` line.
 - [mpm] Move `--cov` and `--cov-report=term` from `pyproject.toml` `[tool.pytest].addopts` into the CI workflow. Removes `pytest-cov` as an unconditional test-time dependency for downstream packagers.


### PR DESCRIPTION
### Description

Fixes changelog release dates and updates availability admonitions.

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`f0deb45a`](https://github.com/kdeldycke/meta-package-manager/commit/f0deb45a86b8d4ac4e6f847b274ba8ba3c558b75) |
| **Job** | [`fix-changelog`](https://github.com/kdeldycke/meta-package-manager/blob/f0deb45a86b8d4ac4e6f847b274ba8ba3c558b75/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/f0deb45a86b8d4ac4e6f847b274ba8ba3c558b75/.github/workflows/changelog.yaml) |
| **Run** | [#1007.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25421161824) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.17.0`