### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -530,11 +530,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "12.0.1"
+version = "12.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/3e/b7dfcbd8ccfb8127f2b907e3c7eabf0ff34bebdc7ae126266fbb7eba7208/extra_platforms-12.0.1.tar.gz", hash = "sha256:55146246c1e4babe385d2438c4da54e3f0078cedc70914288bedbe6502849218", size = 72199, upload-time = "2026-04-26T21:06:51.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/f6/a20c4586c9bd653f596258455652725405f4b734e6270f7fc07a1a498932/extra_platforms-12.0.3.tar.gz", hash = "sha256:0a3201a05f93f18c840f3e9970d33f756a621eea719cbdfa24a514f96c79de7e", size = 72879, upload-time = "2026-04-29T06:47:18.131Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/dc/b61a087ba06eb0a53ebf8d3d51b901e84993a6e0138537d3239f15a82f3c/extra_platforms-12.0.1-py3-none-any.whl", hash = "sha256:e5df76a229c518fe5d12a049d6e54457b2f64bd1c440b185c60256f816b4d747", size = 75447, upload-time = "2026-04-26T21:06:49.757Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ef/efc376476f41868ca834b30ed100b250d53da2b4929ee8e63ef48e7b0b03/extra_platforms-12.0.3-py3-none-any.whl", hash = "sha256:b6b7fad4b41e1f9f161cc74c03d963e43a3a34e0ee1991943314685314b01cf6", size = 76128, upload-time = "2026-04-29T06:47:16.945Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-29`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`12.0.1` → `12.0.3`](https://github.com/kdeldycke/extra-platforms/compare/v12.0.1...v12.0.3) | 2026-04-29 |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v12.0.2`](https://github.com/kdeldycke/extra-platforms/releases/tag/v12.0.2)

> [!NOTE]
> `12.0.2` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/12.0.2/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v12.0.2).

- Move `--cov`, `--cov-report=term`, `--numprocesses=auto`, and `--dist=loadgroup` from `pyproject.toml` `[tool.pytest].addopts` into the CI workflow. Removes `pytest-cov` and `pytest-xdist` as unconditional test-time dependencies for downstream packagers.
- Avoid spurious `cmd /c ver` subprocess calls on Windows in detection functions for non-Windows platforms. `is_macos()` now relies on `sys.platform == "darwin"` directly. `is_illumos()`, `is_solaris()`, `is_sunos()`, `is_wsl1()`, and `is_wsl2()` short-circuit on `sys.platform` before invoking `platform.platform()`, `platform.uname()`, or `platform.release()` (each of which shells out via `platform._syscmd_ver` on Windows). Fixes downstream test suites that globally patch `subprocess.run`.
- Improve test portability: add `network` marker to `test_pyproject_classifiers` (exclude in sandboxed builds with `pytest -m "not network"`); tolerate missing shells in `test_current_funcs` and `test_current_strict_mode` (Guix builders, BusyBox-only images, where shell detection finds nothing).

**Full changelog**: [`v12.0.1...v12.0.2`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v12.0.1...v12.0.2)

#### [`v12.0.3`](https://github.com/kdeldycke/extra-platforms/releases/tag/v12.0.3)

> [!NOTE]
> `12.0.3` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/12.0.3/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v12.0.3).

- Extend missing-shell tolerance to `test_skip_all_shells`, `test_skip_bash`, and `test_skip_powershell` in `tests/test_pytest.py`. The `12.0.2` shell-tolerance work only covered `tests/test_root.py`, leaving these three tests failing on sandboxed builders (Guix, BusyBox-only images) where no shell is detected.

**Full changelog**: [`v12.0.2...v12.0.3`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v12.0.2...v12.0.3)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`851bfd32`](https://github.com/kdeldycke/meta-package-manager/commit/851bfd32271d7ff780495a9d9d7a6b0ea7744832) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/851bfd32271d7ff780495a9d9d7a6b0ea7744832/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/851bfd32271d7ff780495a9d9d7a6b0ea7744832/.github/workflows/autofix.yaml) |
| **Run** | [#2882.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25438979519) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.17.0`