### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,9 +234,6 @@ packages.find.include = [ "meta_package_manager*" ]
 [tool.uv]
 # Cooldown period.
 exclude-newer = "1 week"
-# Bypass the cooldown for click-extra: I maintain it and want new releases
-# (such as 7.15.0's click_extra.theme module) to resolve immediately.
-exclude-newer-package = { click-extra = "0 days" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,9 +11,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
-[options.exclude-newer-package]
-click-extra = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"
@@ -2146,11 +2143,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-04`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [wcwidth](https://pypi.org/project/wcwidth/) | [`0.6.0` → `0.7.0`](https://github.com/jquast/wcwidth/compare/0.6.0...0.7.0) | 2026-05-02 |

### Release notes

<details>
<summary><code>wcwidth</code></summary>

#### [`0.7.0`](https://github.com/jquast/wcwidth/releases/tag/0.7.0)

  * **New** support for kitty text sizing protocol (OSC 66) in `width()` and `clip()`.
  * **New** `clip()` parameter ``control_codes='parse'``, ``'ignore'``, and ``'strict'``. `clip()`
    is now able to clip OSC 8 hyperlinks and OSC 66 text sizing sequences.
  * **Improved** `clip()` and `width()` to support horizontal cursor sequences (``cub``, ``cuf``,
    ``hpa``). Cursor-left (``cub``) or backspace (``\b``) now overwrites text.  column_address
    (``hpa``) and carriage return (``\r``) are now parsed, and more values conditionally raise
    ``ValueError`` when ``control_codes='strict'``.

## PR's

* Remove docs, add utils by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/209
* Bump requests from 2.32.5 to 2.33.0 in /docs by @​dependabot[bot] in https://redirect.github.com/jquast/wcwidth/pull/210
* Bump pygments from 2.19.2 to 2.20.0 in /docs by @​dependabot[bot] in https://redirect.github.com/jquast/wcwidth/pull/212
* dependabot nonsense by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/215
* Expand terminal escape sequence for three more ECMA-48 "families" by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/214
* Improve clip() and width() with hyperlinks and overtyping by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/216
* Improve width() and clip() with kitty Text Sizing Protocol by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/213

**Full Changelog**: https://redirect.github.com/jquast/wcwidth/compare/0.6.0...0.7.0

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`22e77620`](https://github.com/kdeldycke/meta-package-manager/commit/22e7762005c5ac767440bf754f79acdc31e5da1f) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/22e7762005c5ac767440bf754f79acdc31e5da1f/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/22e7762005c5ac767440bf754f79acdc31e5da1f/.github/workflows/autofix.yaml) |
| **Run** | [#2886.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25657858459) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.2`