### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,9 +11,21 @@
 
 ## [`6.4.3` (2026-05-11)](https://github.com/kdeldycke/meta-package-manager/compare/v6.4.2...v6.4.3)
 
+> [!NOTE]
+> `6.4.3` is available on [🐙 GitHub](https://github.com/kdeldycke/meta-package-manager/releases/tag/v6.4.3).
+
+> [!WARNING]
+> `6.4.3` is **not available** on 🐍 PyPI.
+
 - [mpm] Re-release to fix PyPI upload issues.
 
 ## [`6.4.2` (2026-05-08)](https://github.com/kdeldycke/meta-package-manager/compare/v6.4.1...v6.4.2)
+
+> [!NOTE]
+> `6.4.2` is available on [🐙 GitHub](https://github.com/kdeldycke/meta-package-manager/releases/tag/v6.4.2).
+
+> [!WARNING]
+> `6.4.2` is **not available** on 🐍 PyPI.
 
 - [mpm] Compile `version_regexes` with `re.MULTILINE` only, dropping `re.VERBOSE`. Under `re.VERBOSE`, unescaped whitespace in the pattern is silently ignored, so patterns like `r"guix \(GNU Guix\) (?P<version>...)"` would never match `guix --version` output and the manager was reported as unavailable with `could not parse version from <path> output`. Affected `guix`, `nix`, and `stew`, all of which now correctly detect their installed version. `steamcmd`, which used `\ ` escapes to work around the same flag, is unaffected.
 


### PR DESCRIPTION
### Description

Fixes changelog release dates and updates availability admonitions.

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`0c95b404`](https://github.com/kdeldycke/meta-package-manager/commit/0c95b4049c65710d20ba0bc1e358344527ba1ac8) |
| **Job** | [`fix-changelog`](https://github.com/kdeldycke/meta-package-manager/blob/0c95b4049c65710d20ba0bc1e358344527ba1ac8/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/0c95b4049c65710d20ba0bc1e358344527ba1ac8/.github/workflows/changelog.yaml) |
| **Run** | [#1025.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25667962005) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.2`