### PR TITLE
Format Python

### DIFF
--- a/tests/test_manager_pwsh_gallery.py
+++ b/tests/test_manager_pwsh_gallery.py
@@ -72,8 +72,7 @@ def test_parse_json_array_single_entry(manager):
 
 def test_parse_json_array_multiple_entries(manager):
     output = (
-        '[{"Name":"PSReadLine","Version":"2.3.6"},'
-        '{"Name":"Pester","Version":"5.5.0"}]'
+        '[{"Name":"PSReadLine","Version":"2.3.6"},{"Name":"Pester","Version":"5.5.0"}]'
     )
     assert manager._parse_json_array(output) == [
         {"Name": "PSReadLine", "Version": "2.3.6"},
@@ -100,9 +99,7 @@ def test_installed_handles_empty_pipeline(manager, monkeypatch):
 
 
 def test_outdated_yields_only_upgrades(manager, monkeypatch):
-    output = (
-        '[{"Name":"PSReadLine","Installed":"2.3.4","Latest":"2.3.6"}]'
-    )
+    output = '[{"Name":"PSReadLine","Installed":"2.3.4","Latest":"2.3.6"}]'
     monkeypatch.setattr(manager, "run_cli", lambda *a, **kw: output)
     packages = list(manager.outdated)
     assert len(packages) == 1


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`0c95b404`](https://github.com/kdeldycke/meta-package-manager/commit/0c95b4049c65710d20ba0bc1e358344527ba1ac8) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/0c95b4049c65710d20ba0bc1e358344527ba1ac8/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/0c95b4049c65710d20ba0bc1e358344527ba1ac8/.github/workflows/autofix.yaml) |
| **Run** | [#2894.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25667962014) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.2`