### PR TITLE
Fix vulnerable dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,7 @@ packages.find.include = [ "meta_package_manager*" ]
 exclude-newer = "1 week"
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
+exclude-newer-package = { urllib3 = "0 day" }
 
 [tool.nuitka]
 product-name = "Meta Package Manager"

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,9 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
+[options.exclude-newer-package]
+urllib3 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"
@@ -2122,11 +2125,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Upgrades packages with known security vulnerabilities detected by [`uv audit`](https://docs.astral.sh/uv/reference/cli/#uv-audit) against the [Python Packaging Advisory Database](https://github.com/pypa/advisory-database). Uses [`--exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) to bypass the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown for security fixes. See the [`fix-vulnerable-deps` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Vulnerabilities

| Package | Advisory | Current | Fixed | Sources |
| :-- | :-- | :-- | :-- | :-- |
| [urllib3](https://pypi.org/project/urllib3/) | [GHSA-mf9v-mfxr-j63j](https://github.com/urllib3/urllib3/security/advisories/GHSA-mf9v-mfxr-j63j): urllib3: Decompression-bomb safeguards bypassed in parts of the streaming API | `2.6.3` | `2.7.0` | [`github-advisories`](https://github.com/advisories/GHSA-mf9v-mfxr-j63j), [`uv-audit`](https://github.com/urllib3/urllib3/security/advisories/GHSA-mf9v-mfxr-j63j) |
| [urllib3](https://pypi.org/project/urllib3/) | [GHSA-qccp-gfcp-xxvc](https://github.com/urllib3/urllib3/security/advisories/GHSA-qccp-gfcp-xxvc): urllib3: Sensitive headers forwarded across origins in proxied low-level redirects | `2.6.3` | `2.7.0` | [`github-advisories`](https://github.com/advisories/GHSA-qccp-gfcp-xxvc), [`uv-audit`](https://github.com/urllib3/urllib3/security/advisories/GHSA-qccp-gfcp-xxvc) |

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-04`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [urllib3](https://pypi.org/project/urllib3/) | `2.6.3` → `2.7.0` | 2026-05-07 |

### Release notes

<details>
<summary><code>urllib3</code></summary>

#### [`2.7.0`](https://github.com/urllib3/urllib3/releases/tag/2.7.0)

## 🚀 urllib3 is fundraising for HTTP/2 support

[urllib3 is raising ~$40,000 USD](https://sethmlarson.dev/urllib3-is-fundraising-for-http2-support) to release HTTP/2 support and ensure long-term sustainable maintenance of the project after a sharp decline in financial support. If your company or organization uses Python and would benefit from HTTP/2 support in Requests, pip, cloud SDKs, and thousands of other projects [please consider contributing financially](https://opencollective.com/urllib3) to ensure HTTP/2 support is developed sustainably and maintained for the long-haul.

Thank you for your support.

## Security

Addressed high-severity security issues. Impact was limited to specific use cases detailed in the accompanying advisories; overall user exposure was estimated to be marginal.

- Decompression-bomb safeguards of the streaming API were bypassed:

  1. When `HTTPResponse.drain_conn()` was called after the response had been read and decompressed partially. (Reported by @​Cycloctane)
  2. During the second `HTTPResponse.read(amt=N)` or `HTTPResponse.stream(amt=N)` call when the response was decompressed using the official [Brotli](https://pypi.org/project/brotli/) library. (Reported by @​kimkou2024)

  See GHSA-mf9v-mfxr-j63j for details.

- HTTP pools created using `ProxyManager.connection_from_url` did not strip sensitive headers specified in `Retry.remove_headers_on_redirect` when redirecting to a different host. (GHSA-qccp-gfcp-xxvc reported by @​christos-spearbit)

## Deprecations and Removals

- Used `FutureWarning` instead of `DeprecationWarning` for better visibility of existing deprecation notices. Rescheduled the removal of deprecated features to version 3.0. (https://redirect.github.com/urllib3/urllib3/issues/3763)
- Removed support for end-of-life Python 3.9. (https://redirect.github.com/urllib3/urllib3/issues/3720)
- Removed support for end-of-life PyPy3.10. (https://redirect.github.com/urllib3/urllib3/issues/4979)

... [Full release notes](https://github.com/urllib3/urllib3/releases/tag/2.7.0)

</details>


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`6846e8dd`](https://github.com/kdeldycke/meta-package-manager/commit/6846e8ddc99b19d52f96522b447e3b536a7c7972) |
| **Job** | [`fix-vulnerable-deps`](https://github.com/kdeldycke/meta-package-manager/blob/6846e8ddc99b19d52f96522b447e3b536a7c7972/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/6846e8ddc99b19d52f96522b447e3b536a7c7972/.github/workflows/autofix.yaml) |
| **Run** | [#2905.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25692600261) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.3`