### PR TITLE
Format Markdown

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,22 +229,22 @@ Each built-in manager exposes a small set of attributes that can be overridden f
 
 ### Overridable fields
 
-| Field                 | Type                | Description                                                                                |
-| :-------------------- | :------------------ | :----------------------------------------------------------------------------------------- |
-| `cli_names`           | list of strings     | CLI binary names to look for, in order of priority.                                        |
-| `cli_search_path`     | list of strings     | Extra directories searched **before** `$PATH` for the binary.                              |
-| `deprecated`          | boolean             | Mark a manager as deprecated, hiding it from default selection.                            |
-| `dry_run`             | boolean             | Simulate CLI calls without performing any action, only for this manager.                   |
-| `extra_env`           | table of strings    | Additional environment variables passed to every CLI call.                                 |
-| `ignore_auto_updates` | boolean             | Exclude auto-updating packages from outdated/upgrade results, only for this manager.       |
-| `post_args`           | list of strings     | Arguments appended **after** every CLI invocation.                                         |
-| `pre_args`            | list of strings     | Arguments inserted **before** every CLI invocation.                                        |
-| `pre_cmds`            | list of strings     | Commands prepended to every CLI invocation (typically `sudo`).                             |
-| `requirement`         | string              | PEP 440-style version requirement the manager must satisfy to be considered available.     |
-| `stop_on_error`       | boolean             | Stop on the first CLI error from this manager instead of continuing.                       |
-| `timeout`             | integer             | Maximum duration in seconds for each CLI call from this manager.                           |
-| `version_cli_options` | list of strings     | CLI options used to extract the manager's reported version.                                |
-| `version_regexes`     | list of strings     | Regular expressions tried in order to extract the version from CLI output.                 |
+| Field                 | Type             | Description                                                                            |
+| :-------------------- | :--------------- | :------------------------------------------------------------------------------------- |
+| `cli_names`           | list of strings  | CLI binary names to look for, in order of priority.                                    |
+| `cli_search_path`     | list of strings  | Extra directories searched **before** `$PATH` for the binary.                          |
+| `deprecated`          | boolean          | Mark a manager as deprecated, hiding it from default selection.                        |
+| `dry_run`             | boolean          | Simulate CLI calls without performing any action, only for this manager.               |
+| `extra_env`           | table of strings | Additional environment variables passed to every CLI call.                             |
+| `ignore_auto_updates` | boolean          | Exclude auto-updating packages from outdated/upgrade results, only for this manager.   |
+| `post_args`           | list of strings  | Arguments appended **after** every CLI invocation.                                     |
+| `pre_args`            | list of strings  | Arguments inserted **before** every CLI invocation.                                    |
+| `pre_cmds`            | list of strings  | Commands prepended to every CLI invocation (typically `sudo`).                         |
+| `requirement`         | string           | PEP 440-style version requirement the manager must satisfy to be considered available. |
+| `stop_on_error`       | boolean          | Stop on the first CLI error from this manager instead of continuing.                   |
+| `timeout`             | integer          | Maximum duration in seconds for each CLI call from this manager.                       |
+| `version_cli_options` | list of strings  | CLI options used to extract the manager's reported version.                            |
+| `version_regexes`     | list of strings  | Regular expressions tried in order to extract the version from CLI output.             |
 
 ```{important}
 List-valued fields use **replace** semantics: an override fully supersedes the built-in default rather than merging with it. For example, setting `cli_search_path = ["/opt/bin"]` on a manager that ships with `cli_search_path = ("/usr/local/bin",)` results in `("/opt/bin",)`, not the union of both.


### PR DESCRIPTION
### Description

Auto-formats Markdown files with [mdformat](https://github.com/hukkin/mdformat) and its plugins. See the [`format-markdown` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`9fcec645`](https://github.com/kdeldycke/meta-package-manager/commit/9fcec6454bca21b866c0d68b7a9a315fb39659a1) |
| **Job** | [`format-markdown`](https://github.com/kdeldycke/meta-package-manager/blob/9fcec6454bca21b866c0d68b7a9a315fb39659a1/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/9fcec6454bca21b866c0d68b7a9a315fb39659a1/.github/workflows/autofix.yaml) |
| **Run** | [#2919.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25746506164) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.3`