### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/cli.py
+++ b/meta_package_manager/cli.py
@@ -568,9 +568,7 @@ def managers(ctx):
     for manager in ctx.obj.selected_managers(**select_params):
         # Build up the OS column content.
         os_infos = (
-            theme().success(OK_GLYPH)
-            if manager.supported
-            else theme().error(KO_GLYPH)
+            theme().success(OK_GLYPH) if manager.supported else theme().error(KO_GLYPH)
         )
         if not manager.supported:
             os_infos += " {}".format(
@@ -595,9 +593,7 @@ def managers(ctx):
         version_infos = ""
         if manager.executable:
             version_infos = (
-                theme().success(OK_GLYPH)
-                if manager.fresh
-                else theme().error(KO_GLYPH)
+                theme().success(OK_GLYPH) if manager.fresh else theme().error(KO_GLYPH)
             )
             if manager.version:
                 version_infos += f" {manager.version}"

--- a/meta_package_manager/config.py
+++ b/meta_package_manager/config.py
@@ -153,8 +153,7 @@ def _to_str_dict(value: Any) -> dict[str, str]:
     for k, v in value.items():
         if not isinstance(k, str) or not isinstance(v, str):
             raise TypeError(
-                f"expected a table of string-to-string entries, "
-                f"got {k!r} = {v!r}"
+                f"expected a table of string-to-string entries, got {k!r} = {v!r}"
             )
     return dict(value)
 
@@ -350,20 +349,15 @@ def format_contribution_hints(hints: list[ContributionHint]) -> str:
     ]
     for hint in hints:
         url = _build_issue_url(hint)
-        lines.extend(
-            (
-                f"  - {theme().invoked_command(hint.manager_id)}: "
-                f"override on `{hint.field}`",
-                f"    File a report: {url}",
-            )
-        )
-    lines.extend(
-        (
-            "",
-            "  (Disable with `--no-suggest-contribs` or "
-            "`[mpm] suggest_contribs = false`.)",
-        )
-    )
+        lines.extend((
+            f"  - {theme().invoked_command(hint.manager_id)}: "
+            f"override on `{hint.field}`",
+            f"    File a report: {url}",
+        ))
+    lines.extend((
+        "",
+        "  (Disable with `--no-suggest-contribs` or `[mpm] suggest_contribs = false`.)",
+    ))
     return "\n".join(lines)
 
 
@@ -392,9 +386,7 @@ def validate_manager_overrides_section(
     if not section:
         return
     if not isinstance(section, dict):
-        raise ValidationError(
-            "", f"expected a table, got {type(section).__name__}"
-        )
+        raise ValidationError("", f"expected a table, got {type(section).__name__}")
     for manager_id, fields in section.items():
         if manager_id not in pool.register:
             raise ValidationError(
@@ -413,8 +405,7 @@ def validate_manager_overrides_section(
             if converter is None:
                 raise ValidationError(
                     f"{manager_id}.{field_name}",
-                    f"unknown field. "
-                    f"Allowed: {', '.join(sorted(OVERRIDABLE_FIELDS))}",
+                    f"unknown field. Allowed: {', '.join(sorted(OVERRIDABLE_FIELDS))}",
                     code="unknown_field",
                 )
             try:
@@ -513,6 +504,7 @@ def build_manager_overrides_validator(pool: ManagerPool) -> ConfigValidator:
     (``Callable[[dict], None]``) while keeping the underlying validator pool-agnostic
     and testable in isolation.
     """
+
     def _validator(section: dict[str, Any]) -> None:
         validate_manager_overrides_section(section, pool=pool)
 

--- a/meta_package_manager/managers/topgrade.py
+++ b/meta_package_manager/managers/topgrade.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from extra_platforms import BSD, LINUX_LIKE, MACOS, ALL_WINDOWS
+from extra_platforms import ALL_WINDOWS, BSD, LINUX_LIKE, MACOS
 
 from ..base import PackageManager
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -264,9 +264,7 @@ def test_benchmark_homepages_cover_non_pool_managers():
 
     # Homepages must not duplicate pool managers (those come from the class).
     overlap = homepage_ids & pool_ids
-    assert not overlap, (
-        f"Pool managers must not appear in homepages: {sorted(overlap)}"
-    )
+    assert not overlap, f"Pool managers must not appear in homepages: {sorted(overlap)}"
 
     # Homepages must not include unknown manager IDs.
     extra = homepage_ids - yaml_ids

--- a/tests/test_manager_overrides.py
+++ b/tests/test_manager_overrides.py
@@ -24,7 +24,6 @@ from textwrap import dedent
 
 import pytest
 import tomli_w
-
 from click_extra import ValidationError
 
 from meta_package_manager.config import (
@@ -118,27 +117,28 @@ def test_unknown_manager_raises():
 def test_non_dict_manager_section_raises():
     with pytest.raises(ValidationError, match=r"expected a table"):
         apply_manager_overrides(
-            pool, {OVERRIDE_TARGET: "not a table"}  # type: ignore[dict-item]
+            pool,
+            {OVERRIDE_TARGET: "not a table"},  # type: ignore[dict-item]
         )
 
 
 def test_unknown_field_raises(reset_overrides):
     with pytest.raises(ValidationError, match=r"unknown field"):
-        apply_manager_overrides(
-            pool, {OVERRIDE_TARGET: {"made_up_field": 99}}
-        )
+        apply_manager_overrides(pool, {OVERRIDE_TARGET: {"made_up_field": 99}})
 
 
 def test_str_tuple_override_replaces_default(reset_overrides):
     new_path = ("/opt/custom/bin", "/usr/local/special")
-    apply_manager_overrides(pool, {OVERRIDE_TARGET: {"cli_search_path": list(new_path)}})
+    apply_manager_overrides(
+        pool, {OVERRIDE_TARGET: {"cli_search_path": list(new_path)}}
+    )
     assert pool[OVERRIDE_TARGET].cli_search_path == new_path
     assert "cli_search_path" in pool[OVERRIDE_TARGET].__dict__
 
 
 def test_str_tuple_override_coerces_list_to_tuple(reset_overrides):
-    apply_manager_overrides(pool,
-        {OVERRIDE_TARGET: {"cli_names": ["pip3", "pip", "pip2"]}}
+    apply_manager_overrides(
+        pool, {OVERRIDE_TARGET: {"cli_names": ["pip3", "pip", "pip2"]}}
     )
     assert pool[OVERRIDE_TARGET].cli_names == ("pip3", "pip", "pip2")
     assert isinstance(pool[OVERRIDE_TARGET].cli_names, tuple)
@@ -146,15 +146,15 @@ def test_str_tuple_override_coerces_list_to_tuple(reset_overrides):
 
 def test_str_tuple_override_rejects_bare_string(reset_overrides):
     with pytest.raises(ValidationError, match=r"expected a list of strings"):
-        apply_manager_overrides(pool,
-            {OVERRIDE_TARGET: {"cli_search_path": "/single/path"}}
+        apply_manager_overrides(
+            pool, {OVERRIDE_TARGET: {"cli_search_path": "/single/path"}}
         )
 
 
 def test_str_tuple_override_rejects_non_string_entries(reset_overrides):
     with pytest.raises(ValidationError, match=r"expected all entries to be strings"):
-        apply_manager_overrides(pool,
-            {OVERRIDE_TARGET: {"cli_search_path": ["/ok", 42]}}
+        apply_manager_overrides(
+            pool, {OVERRIDE_TARGET: {"cli_search_path": ["/ok", 42]}}
         )
 
 
@@ -196,12 +196,11 @@ def test_str_override_rejects_int(reset_overrides):
 
 
 def test_dict_override(reset_overrides):
-    apply_manager_overrides(pool,
-        {OVERRIDE_TARGET: {"extra_env": {"PIP_INDEX_URL": "https://example.test"}}}
+    apply_manager_overrides(
+        pool,
+        {OVERRIDE_TARGET: {"extra_env": {"PIP_INDEX_URL": "https://example.test"}}},
     )
-    assert pool[OVERRIDE_TARGET].extra_env == {
-        "PIP_INDEX_URL": "https://example.test"
-    }
+    assert pool[OVERRIDE_TARGET].extra_env == {"PIP_INDEX_URL": "https://example.test"}
 
 
 def test_dict_override_rejects_non_string_value(reset_overrides):
@@ -210,14 +209,15 @@ def test_dict_override_rejects_non_string_value(reset_overrides):
 
 
 def test_multiple_fields_in_one_call(reset_overrides):
-    apply_manager_overrides(pool,
+    apply_manager_overrides(
+        pool,
         {
             OVERRIDE_TARGET: {
                 "cli_search_path": ["/x"],
                 "timeout": 60,
                 "ignore_auto_updates": False,
             }
-        }
+        },
     )
     manager = pool[OVERRIDE_TARGET]
     assert manager.cli_search_path == ("/x",)
@@ -232,7 +232,9 @@ def test_cached_property_evicted_on_override(reset_overrides):
     _ = manager.cli_path
     # `cli_path` may or may not have been resolved on this host; what matters is that
     # if it WAS computed, the cache entry is cleared so a follow-up access recomputes.
-    apply_manager_overrides(pool, {OVERRIDE_TARGET: {"cli_search_path": ["/elsewhere"]}})
+    apply_manager_overrides(
+        pool, {OVERRIDE_TARGET: {"cli_search_path": ["/elsewhere"]}}
+    )
     assert "cli_path" not in manager.__dict__
 
 
@@ -464,7 +466,9 @@ def test_format_contribution_hints_lists_each_with_url():
     msg = format_contribution_hints(hints)
     assert "winget" in msg
     assert "cargo" in msg
-    assert msg.count("https://github.com/kdeldycke/meta-package-manager/issues/new") == 2
+    assert (
+        msg.count("https://github.com/kdeldycke/meta-package-manager/issues/new") == 2
+    )
     # Mentions the opt-out so the user knows how to silence.
     assert "--no-suggest-contribs" in msg
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`27e009ed`](https://github.com/kdeldycke/meta-package-manager/commit/27e009ed2c76f5327e0c9bddb2f9139814b521ff) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/27e009ed2c76f5327e0c9bddb2f9139814b521ff/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/27e009ed2c76f5327e0c9bddb2f9139814b521ff/.github/workflows/autofix.yaml) |
| **Run** | [#2941.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25902224676) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.4`