### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -284,9 +284,12 @@ pytest = [
     { name = "pytest" },
 ]
 sphinx = [
-    { name = "docutils" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pygments" },
-    { name = "sphinx" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 toml = [
     { name = "tomlkit" },
@@ -483,9 +486,25 @@ wheels = [
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -535,7 +554,9 @@ dependencies = [
     { name = "accessible-pygments" },
     { name = "beautifulsoup4" },
     { name = "pygments" },
-    { name = "sphinx" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-basic-ng" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
@@ -822,12 +843,31 @@ wheels = [
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -920,7 +960,8 @@ name = "mdit-py-plugins"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/3d/e0e8d9d1cee04f758120915e2b2a3a07eb41f8cf4654b4734788a522bcd1/mdit_py_plugins-0.6.0.tar.gz", hash = "sha256:2436f14a7295837ac9228a36feeabda867c4abc488c8d019ad5c0bda88eee040", size = 56025, upload-time = "2026-05-07T12:20:42.295Z" }
 wheels = [
@@ -977,9 +1018,14 @@ yaml = [
 docs = [
     { name = "click-extra", extra = ["sphinx"] },
     { name = "furo" },
-    { name = "myst-parser" },
-    { name = "sphinx" },
-    { name = "sphinx-autodoc-typehints" },
+    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx-autodoc-typehints", version = "3.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-click" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1062,17 +1108,42 @@ typing = [
 name = "myst-parser"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "docutils" },
-    { name = "jinja2" },
-    { name = "markdown-it-py" },
-    { name = "mdit-py-plugins" },
-    { name = "pyyaml" },
-    { name = "sphinx" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
+    { name = "pyyaml", marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d", size = 84579, upload-time = "2025-02-12T10:53:02.078Z" },
+]
+
+[[package]]
+name = "myst-parser"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl", hash = "sha256:ab31e516024918296e169139072b81592336f2fef55b8986aa31c9f04b5f7211", size = 84533, upload-time = "2026-01-15T09:08:16.788Z" },
 ]
 
 [[package]]
@@ -1395,6 +1466,15 @@ wheels = [
 ]
 
 [[package]]
+name = "roman-numerals"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1585,23 +1665,26 @@ wheels = [
 name = "sphinx"
 version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
@@ -1610,11 +1693,76 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx"
+version = "9.0.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
+    { name = "babel", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
+    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
+    { name = "packaging", marker = "python_full_version == '3.11.*'" },
+    { name = "pygments", marker = "python_full_version == '3.11.*'" },
+    { name = "requests", marker = "python_full_version == '3.11.*'" },
+    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
+    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/3f/4bbd76424c393caead2e1eb89777f575dee5c8653e2d4b6afd7a564f5974/sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb", size = 3917713, upload-time = "2025-12-04T07:45:24.944Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version >= '3.12'" },
+    { name = "babel", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "imagesize", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
+]
+
+[[package]]
 name = "sphinx-autodoc-typehints"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "sphinx" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/f0/43c6a5ff3e7b08a8c3b32f81b859f1b518ccc31e45f22e2b41ced38be7b9/sphinx_autodoc_typehints-3.0.1.tar.gz", hash = "sha256:b9b40dd15dee54f6f810c924f863f9cf1c54f9f3265c495140ea01be7f44fa55", size = 36282, upload-time = "2025-01-16T18:25:30.958Z" }
 wheels = [
@@ -1622,11 +1770,43 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-autodoc-typehints"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/f6/bdd93582b2aaad2cfe9eb5695a44883c8bc44572dd3c351a947acbb13789/sphinx_autodoc_typehints-3.6.1.tar.gz", hash = "sha256:fa0b686ae1b85965116c88260e5e4b82faec3687c2e94d6a10f9b36c3743e2fe", size = 37563, upload-time = "2026-01-02T15:23:46.543Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/6a/c0360b115c81d449b3b73bf74b64ca773464d5c7b1b77bda87c5e874853b/sphinx_autodoc_typehints-3.6.1-py3-none-any.whl", hash = "sha256:dd818ba31d4c97f219a8c0fcacef280424f84a3589cedcb73003ad99c7da41ca", size = 20869, upload-time = "2026-01-02T15:23:45.194Z" },
+]
+
+[[package]]
+name = "sphinx-autodoc-typehints"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/75/9a5695b3d3b848a43cfe91c7d7d3c5ab543eb3bc5c2a12ffaf5003a2a4f6/sphinx_autodoc_typehints-3.10.2.tar.gz", hash = "sha256:34db651eb14343ba16bd9c03e0f5093971f9bbd3cc6b0a1470adecd578940b9c", size = 74241, upload-time = "2026-04-15T22:09:48.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/0f/f1c2e2592f995d301bc06901fbb2e947cbe4889397a418309710ccc3a1db/sphinx_autodoc_typehints-3.10.2-py3-none-any.whl", hash = "sha256:2d1bcac8f62b8d0d210f6ca44b8e016e314d07cc8c30d0512cf6986a0b042b26", size = 39231, upload-time = "2026-04-15T22:09:47.413Z" },
+]
+
+[[package]]
 name = "sphinx-basic-ng"
 version = "1.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
 wheels = [
@@ -1639,8 +1819,11 @@ version = "6.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "docutils" },
-    { name = "sphinx" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/ed/a9767cd1b8b7fbdf260a89d5c8c86e20e3536b9878579e5ab7965a291e55/sphinx_click-6.2.0.tar.gz", hash = "sha256:fc78b4154a4e5159462e36de55b8643747da6cda86b3b52a8bb62289e603776c", size = 27035, upload-time = "2025-12-04T19:33:05.437Z" }
 wheels = [
@@ -1652,7 +1835,9 @@ name = "sphinx-copybutton"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
 wheels = [
@@ -1667,7 +1852,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "sphinx", marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -1683,7 +1868,8 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "sphinx", marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
 wheels = [
@@ -1695,7 +1881,9 @@ name = "sphinx-issues"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/4e/c9a46b19c90d4d3cdcbcaf0e4d392b09e5b41ec75b134bc5a1aa192be94f/sphinx_issues-6.0.0.tar.gz", hash = "sha256:f40f2c71cecb2068c7f06a53825778b674d58d8395b4ea60551a36164d2988e3", size = 15230, upload-time = "2026-03-13T17:23:32.501Z" }
 wheels = [
@@ -1745,7 +1933,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "pyyaml" },
-    { name = "sphinx" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/3a1cc926da8c563c58ddc124a7b3fe5ccadcae96c96e3a6f8ac3653a210a/sphinxcontrib_mermaid-2.0.2.tar.gz", hash = "sha256:f09576c78ca93fa0e3034fd9c45aaffa7c44ab449de9c43b8b8d262afe52bc66", size = 19265, upload-time = "2026-05-05T13:59:02.959Z" }
 wheels = [
@@ -1775,7 +1965,9 @@ name = "sphinxext-opengraph"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/c0/eb6838e3bae624ce6c8b90b245d17e84252863150e95efdb88f92c8aa3fb/sphinxext_opengraph-0.13.0.tar.gz", hash = "sha256:103335d08567ad8468faf1425f575e3b698e9621f9323949a6c8b96d9793e80b", size = 1026875, upload-time = "2025-08-29T12:20:31.066Z" }
 wheels = [


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-09`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [docutils](https://pypi.org/project/docutils/) | `0.21.2` → `0.22.4` | 2025-12-18 |
| [markdown-it-py](https://pypi.org/project/markdown-it-py/) | [`3.0.0` → `4.2.0`](https://github.com/executablebooks/markdown-it-py/compare/v3.0.0...v4.2.0) | 2026-05-07 |
| [myst-parser](https://pypi.org/project/myst-parser/) | [`4.0.1` → `5.0.0`](https://github.com/executablebooks/MyST-Parser/compare/v4.0.1...v5.0.0) | 2026-01-15 |
| [roman-numerals](https://pypi.org/project/roman-numerals/) | (new) `4.1.0` | 2025-12-17 |
| [sphinx](https://pypi.org/project/sphinx/) | [`8.1.3` → `9.1.0`](https://github.com/sphinx-doc/sphinx/compare/v8.1.3...v9.1.0) | 2025-12-31 |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.0.1` → `3.10.2`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.0.1...3.10.2) | 2026-04-15 |

### Release notes

<details>
<summary><code>markdown-it-py</code></summary>

#### [`v4.0.0`](https://github.com/executablebooks/markdown-it-py/releases/tag/v4.0.0)

## What's Changed

This primarily drops support for Python 3.8 and 3.9, adds support for Python 3.13,
and updates the parser to comply with Commonmark 0.31.2 and Markdown-It v14.1.0.

### Upgrades

* ⬆️ Drop Python 3.8, test 3.13 by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/342
* ⬆️ Drop support for Python 3.9 by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/360
* ⬆️ Comply with Commonmark 0.31.2 by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/362

### Improvements

* 👌 Improve performance of "text" inline rule by @​hukkin in https://redirect.github.com/executablebooks/markdown-it-py/pull/347
* 👌 Use `str.removesuffix` by @​hukkin in https://redirect.github.com/executablebooks/markdown-it-py/pull/348
* 👌 limit the number of autocompleted cells in a table by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/364
* 👌 fix quadratic complexity in reference parser by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/367

### Bug fixes

* 🐛 Fix emphasis inside raw links bugs by @​tsutsu3 in https://redirect.github.com/executablebooks/markdown-it-py/pull/320

### Maintenance

* 🔧 Replace black and isort with ruff formatter by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/313
* 🔧 Fixed Code Style paragraph still referring to flake8 by @​venthur in https://redirect.github.com/executablebooks/markdown-it-py/pull/309
* 🔧 Add "store_labels" to OptionsType by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/343
* 🔧 Move `code_style` to dependency group by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/344
* 🔧 Update codecov action by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/345

... [Full release notes](https://github.com/executablebooks/markdown-it-py/releases/tag/v4.0.0)

#### [`v4.1.0`](https://github.com/executablebooks/markdown-it-py/releases/tag/v4.1.0)

## What's Changed
* ✨ Add `--stdin` option to CLI by @​mcepl in https://redirect.github.com/executablebooks/markdown-it-py/pull/379
* Add AGENTS.md and copilot-setup-steps workflow by @​Copilot in https://redirect.github.com/executablebooks/markdown-it-py/pull/380
* 🔧 Add typing to Scanner by @​Alunderin in https://redirect.github.com/executablebooks/markdown-it-py/pull/382
* 👌 Fix quadratic complexity in `fragments_join` / `text_join` by @​petricevich in https://redirect.github.com/executablebooks/markdown-it-py/pull/389
* ✨Allow plugins to register inline terminator characters by @​Copilot in https://redirect.github.com/executablebooks/markdown-it-py/pull/391
* ✨ Add `gfm-like2` preset with task lists, alerts, and single-tilde strikethrough by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/388
* 🔧 Update pre-commit hooks by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/392
* 🚀 RELEASE v4.1.0 by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/393

## New Contributors
* @​mcepl made their first contribution in https://redirect.github.com/executablebooks/markdown-it-py/pull/379
* @​Copilot made their first contribution in https://redirect.github.com/executablebooks/markdown-it-py/pull/380
* @​Alunderin made their first contribution in https://redirect.github.com/executablebooks/markdown-it-py/pull/382
* @​petricevich made their first contribution in https://redirect.github.com/executablebooks/markdown-it-py/pull/389

**Full Changelog**: https://redirect.github.com/executablebooks/markdown-it-py/compare/v4.0.0...v4.1.0

#### [`v4.2.0`](https://github.com/executablebooks/markdown-it-py/releases/tag/v4.2.0)

## What's Changed
* ✨ Add `make_fence_rule()` factory for configurable fence markers by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/394
* 🚀 RELEASE v4.2.0 by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/395


**Full Changelog**: https://redirect.github.com/executablebooks/markdown-it-py/compare/v4.1.0...v4.2.0

</details>

<details>
<summary><code>myst-parser</code></summary>

#### [`v5.0.0`](https://github.com/executablebooks/MyST-Parser/releases/tag/v5.0.0)

# MyST-Parser 5.0.0

**Release Date**: 2026-01-15

This release significantly bumps the supported versions of core dependencies:

## ‼️ Breaking Changes

This release updates the minimum supported versions:

- **Python**: `>=3.11` (dropped Python 3.10, tests up to 3.14)
- **Sphinx**: `>=8,<10` (dropped Sphinx 7, added Sphinx 9)
- **Docutils**: `>=0.20,<0.23` (dropped docutils 0.19, added docutils 0.22)
- **markdown-it-py**: `~=4.0` (upgraded from v3)

## ⬆️ Dependency Upgrades

- ⬆️ Upgrade to markdown-it-py v4 by [@​chrisjsewell](https://redirect.github.com/chrisjsewell) in [#​1060](https://redirect.github.com/executablebooks/MyST-Parser/pull/1060)
- ⬆️ Drop Python 3.10 and Sphinx 7 by [@​chrisjsewell](https://redirect.github.com/chrisjsewell) in [#​1059](https://redirect.github.com/executablebooks/MyST-Parser/pull/1059)
- ⬆️ Drop docutils 0.19 by [@​chrisjsewell](https://redirect.github.com/chrisjsewell) in [#​1061](https://redirect.github.com/executablebooks/MyST-Parser/pull/1061)
- ⬆️ Add support for Python 3.14 by [@​chrisjsewell](https://redirect.github.com/chrisjsewell) in [#​1075](https://redirect.github.com/executablebooks/MyST-Parser/pull/1075)
- ⬆️ Support Sphinx v9 by [@​chrisjsewell](https://redirect.github.com/chrisjsewell) in [#​1076](https://redirect.github.com/executablebooks/MyST-Parser/pull/1076)
- ⬆️ Allow docutils 0.22 by [@​chrisjsewell](https://redirect.github.com/chrisjsewell) in [#​1084](https://redirect.github.com/executablebooks/MyST-Parser/pull/1084)

## 👌 Improvements

- 👌 Improve generation of meta nodes by [@​AA-Turner](https://redirect.github.com/AA-Turner) in [#​1080](https://redirect.github.com/executablebooks/MyST-Parser/pull/1080)

## 📚 Documentation

- 📚 Fix typo in tables.md by [@​electricalgorithm](https://redirect.github.com/electricalgorithm) in [#​1034](https://redirect.github.com/executablebooks/MyST-Parser/pull/1034)

... [Full release notes](https://github.com/executablebooks/MyST-Parser/releases/tag/v5.0.0)

</details>

<details>
<summary><code>roman-numerals</code></summary>

#### [`v4.1.0`](https://github.com/AA-Turner/roman-numerals/releases/tag/v4.1.0)

roman-numerals 4.1.0

</details>

<details>
<summary><code>sphinx</code></summary>

#### [`v8.2.0rc1`](https://github.com/sphinx-doc/sphinx/releases/tag/v8.2.0rc1)

Changelog: https://www.sphinx-doc.org/en/master/changes/8.2.html

#### [`v8.2.0rc2`](https://github.com/sphinx-doc/sphinx/releases/tag/v8.2.0rc2)

Changelog: https://www.sphinx-doc.org/en/master/changes/8.2.html

#### [`v8.2.0`](https://github.com/sphinx-doc/sphinx/releases/tag/v8.2.0)

Changelog: https://www.sphinx-doc.org/en/master/changes/8.2.html


Dependencies
------------

* #​13000: Drop Python 3.10 support.

Incompatible changes
--------------------

* #​13044: Remove the internal and undocumented ``has_equations`` data
  from the `MathDomain` domain.
  The undocumented `MathDomain.has_equations` method
  now unconditionally returns ``True``.
  These are replaced by the ``has_maths_elements`` key of the page context dict.
  Patch by Adam Turner.
* #​13227: HTML output for sequences of keys in the `kbd` role
  no longer uses a ``<kbd class="kbd compound">`` element to wrap
  the keys and separators, but places them directly in the relevant parent node.
  This means that CSS rulesets targeting ``kbd.compound`` or ``.kbd.compound``
  will no longer have any effect.
  Patch by Adam Turner.

Deprecated
----------

* #​13037: Deprecate the ``SingleHTMLBuilder.fix_refuris`` method.
  Patch by James Addison.
* #​13083, #​13330: Un-deprecate ``sphinx.util.import_object``.
  Patch by Matthias Geier.

Features added
--------------

* #​13173: Add a new ``duplicate_declaration`` warning type,
  with ``duplicate_declaration.c`` and ``duplicate_declaration.cpp`` subtypes.
  Patch by Julien Lecomte and Adam Turner.
* #​11824: linkcode: Allow extensions to add support for a domain by defining
  the keys that should be present.
  Patch by Nicolas Peugnet.
* #​13144: Add a ``class`` option to the `autosummary` directive.
  Patch by Tim Hoffmann.
* #​13146: Napoleon: Unify the type preprocessing logic to allow
  Google-style docstrings to use the optional and default keywords.
  Patch by Chris Barrick.
* #​13227: Implement the `kbd` role as a ``SphinxRole``.
  Patch by Adam Turner.
* #​13065: Enable colour by default in when running on CI.
  Patch by Adam Turner.
* #​13230: Allow supressing warnings from the `toctree` directive
  when a glob pattern doesn't match any documents,

... [Full release notes](https://github.com/sphinx-doc/sphinx/releases/tag/v8.2.0)

#### [`v8.2.1`](https://github.com/sphinx-doc/sphinx/releases/tag/v8.2.1)

Changelog: https://www.sphinx-doc.org/en/master/changes/8.2.html

#### [`v8.2.2`](https://github.com/sphinx-doc/sphinx/releases/tag/v8.2.2)

Changelog: https://www.sphinx-doc.org/en/master/changes/8.2.html

#### [`v8.2.3`](https://github.com/sphinx-doc/sphinx/releases/tag/v8.2.3)

Changelog: https://www.sphinx-doc.org/en/master/changes/8.2.html

#### [`v9.0.0rc1`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0rc1)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

#### [`v9.0.0rc2`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0rc2)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

#### [`v9.0.0rc3`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0rc3)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

#### [`v9.0.0rc4`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0rc4)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

#### [`v9.0.0`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html


Dependencies
------------

* #​13786: Support [Docutils 0.22](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-22-2026-07-29). Patch by Adam Turner.

Incompatible changes
--------------------

* #​13639: `SphinxComponentRegistry.create_source_parser` no longer
  has an *app* parameter, instead taking *config* and *env*.
  Patch by Adam Turner.
* #​13679: Non-decodable characters in source files now raise an error.
  Such bytes have been replaced with '?' along with logging a warning
  since Sphinx 2.0.
  Patch by Adam Turner.
* #​13751, #​14089: `sphinx.ext.autodoc` has been substantially rewritten,
  and there may be some incompatible changes in edge cases, especially when
  extensions interact with autodoc internals.
  The `autodoc_use_legacy_class_based` option has been added to
  use the legacy (pre-9.0) implementation of autodoc.
  Patches by Adam Turner.
* #​13355: Don't include escaped title content in the search index.
  Patch by Will Lachance.

Deprecated
----------

* 13627: Deprecate remaining public `app` attributes,
  including ``builder.app``, ``env.app``, ``events.app``,
  and ``SphinxTransform.app``.
  Patch by Adam Turner.
* #​13637: Deprecate the `set_application` method
  of `Parser` objects.
  Patch by Adam Turner.
* #​13644: Deprecate the `Parser.config` and `env` attributes.
  Patch by Adam Turner.
* #​13665: Deprecate support for non-UTF 8 source encodings,
  scheduled for removal in Sphinx 10.
  Patch by Adam Turner.
* #​13682: Deprecate `sphinx.io`.
  Sphinx no longer uses the `sphinx.io` classes,
  having replaced them with standard Python I/O.
  The entire `sphinx.io` module will be removed in Sphinx 10.
  Patch by Adam Turner.
* #​13631: `sphinx.environment.adapters.toctree.global_toctree_for_doc`
  and `sphinx.environment.BuildEnvironment.get_and_resolve_doctree`

... [Full release notes](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0)

#### [`v9.0.1`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.1)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

Bugs fixed
----------

* #​13942: autodoc: Restore the mapping interface for options objects.
  Patch by Adam Turner.
* #​13942: autodoc: Deprecate the mapping interface for options objects.
  Patch by Adam Turner.
* #​13387: Update translations.

#### [`v9.0.2`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.2)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

Bugs fixed
----------

* #​14142: autodoc: Restore `sphinx.ext.autodoc.mock`.
  Patch by Adam Turner.

#### [`v9.0.3`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.3)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

Bugs fixed
----------

* #​14142: autodoc: Restore some missing exports in `sphinx.ext.autodoc`.
  Patch by Adam Turner.

#### [`v9.0.4`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.4)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

Bugs fixed
----------

* #​14143: Fix spurious build warnings when translators reorder references
  in strings, or use translated display text in references.
  Patch by Matt Wang.

#### [`v9.1.0rc1`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.1.0rc1)

Changelog: https://www.sphinx-doc.org/en/master/changes.html

#### [`v9.1.0rc2`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.1.0rc2)

Changelog: https://www.sphinx-doc.org/en/master/changes.html

#### [`v9.1.0`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.1.0)

Changelog: https://www.sphinx-doc.org/en/master/changes.html

Dependencies
------------

* #​14153: Drop Python 3.11 support.
* #​12555: Drop Docutils 0.20 support.
  Patch by Adam Turner

Features added
--------------

* Add `add_static_dir()` for copying static
  assets from extensions to the build output.
  Patch by Jared Dillard

Bugs fixed
----------

* #​14189: autodoc: Fix duplicate ``:no-index-entry:`` for modules.
  Patch by Adam Turner
* #​13713: Fix compatibility with MyST-Parser.
  Patch by Adam Turner
* Fix tests for Python 3.15.
  Patch by Adam Turner
* #​14089: autodoc: Fix default option parsing.
  Patch by Adam Turner
* Remove incorrect static typing assertions.
  Patch by Adam Turner
* #​14050: LaTeXTranslator fails to build documents using the "acronym"
  standard role.
  Patch by Günter Milde
* LaTeX: Fix rendering for grid filled merged vertical cell.
  Patch by Tim Nordell
* #​14228: LaTeX: Fix overrun footer for cases of merged vertical table cells.
  Patch by Tim Nordell
* #​14207: Fix creating ``HTMLThemeFactory`` objects in third-party extensions.
  Patch by Adam Turner
* #​3099: LaTeX: PDF build crashes if a code-block contains more than
  circa 1350 codelines (about 27 a4-sized pages at default pointsize).
  Patch by Jean-François B.
* #​14064: LaTeX: TABs ending up in sphinxVerbatim fail to obey tab stops.
  Patch by Jean-François B.
* #​14089: autodoc: Improve support for non-weakreferencable objects.
  Patch by Adam Turner
* LaTeX: Fix accidental removal at ``3.5.0`` (#​8854) of the documentation of
  ``literalblockcappos`` key of  sphinxsetup.
  Patch by Jean-François B.

</details>

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.1.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.1.0)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Support Sphinx 8.2.0 - drop 3.10 support because Sphinx does by @​b-kamphorst in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/525

## New Contributors
* @​b-kamphorst made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/525

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.0.1...3.1.0

#### [`3.2.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.2.0)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fixed broken changelog link by @​agronholm in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/530
* Fix issue #​481 by @​nineteendo in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/533
* Don't add :rtype: None by @​grayjk in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/538
* Place rtype after directive by @​grayjk in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/537

## New Contributors
* @​agronholm made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/530
* @​nineteendo made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/533
* @​grayjk made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/538

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.1.0...3.2.0

#### [`3.3.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.3.0)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed

* Warning types and subtypes by @​fajpunk in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/562

## New Contributors
* @​fajpunk made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/562

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.2.0...3.3.0

#### [`3.4.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.4.0)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Python 3.14 support by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/569


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.3.0...3.4.0

#### [`3.5.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.5.0)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Support Union type on its own by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/570


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.4.0...3.5.0

#### [`3.5.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.5.1)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Declare 3.14 support by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/571


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.5.0...3.5.1

#### [`3.5.2`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.5.2)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Preserve type information from docstrings if no type annotation is present and parameter has default value. by @​christianaguilera-foundry in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/576

## New Contributors
* @​christianaguilera-foundry made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/576

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.5.1...3.5.2

#### [`3.6.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.6.0)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Use Sphinx 9 class interface by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/589


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.5.2...3.6.0

#### [`3.6.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.6.1)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Include metadata in type hints by @​AllanChain in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/594

## New Contributors
* @​AllanChain made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/594

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.6.0...3.6.1

#### [`3.6.2`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.6.2)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix compatibility with 9.1.0 by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/595


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.6.1...3.6.2

#### [`3.6.3`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.6.3)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* 🔧 build(tox): migrate from tox.ini to tox.toml by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/609
* Fix extra () after NewType in rendered output by @​Fridayai700 in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/608
* Fix ValueError on wrapper loops in inspect.unwrap by @​Fridayai700 in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/607
* Fix IndexError with always_document_param_types and braces-after defaults by @​Fridayai700 in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/605
* Fix warning for __new__ of NamedTuple subclasses by @​Fridayai700 in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/606

## New Contributors
* @​Fridayai700 made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/608

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.6.2...3.6.3

#### [`3.7.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.7.0)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Migrate type checking from mypy to ty by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/611
* Move from extras to dependency-groups by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/612
* 🐛 fix(types): resolve PEP 695 type params in annotations by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/614
* fix: separate injected :rtype: from preceding paragraph by @​lweyrich1 in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/615
* 🐛 fix(rtype): skip Return type for generators with Yields by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/616
* 🐛 fix(guard): silence ImportError for third-party guards by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/617
* 🐛 fix(sig): prevent KeyError in method lookup by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/620
* 🐛 fix(annotations): show NewType as alias name with supertype by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/622
* 🐛 fix(annotations): link enum variants in Literal types by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/623
* 🐛 fix(parser): prevent directive side-effects in snippet parsing by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/624

## New Contributors
* @​lweyrich1 made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/615

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.6.3...3.7.0

#### [`3.8.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.8.0)

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* ✨ feat(signatures): enable overload signature display by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/625
* ✨ feat(annotations): preserve documented type aliases by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/626
* ✨ feat(annotations): use annotationlib on 3.14+ for forward refs by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/627
* ♻️ refactor(core): extract format-specific submodules by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/628
* ✨ feat(warnings): add source location context by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/629
* ✨ feat(stubs): resolve type hints from .pyi stub files (#​161) by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/630
* ✨ feat(annotations): support Annotated with Doc() for param descriptions by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/631
* 🧪 test(output): normalize Sphinx text for stable comparisons by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/632
* ✨ feat(attrs): backfill type annotations for attrs classes by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/633
* 📝 docs(readme): rewrite with Diataxis framework by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/634


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.7.0...3.8.0

#### [`3.9.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.0)

<!-- Release notes generated using configuration in .github/release.yaml at 3.9.0 -->

## What's Changed
* Add permissions to workflows by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/636
* ♻️ refactor(tests): consolidate test infrastructure and reach 100% coverage by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/635
* Move SECURITY.md to .github/SECURITY.md by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/639
* Switch FUNDING.yml to github: gaborbernat by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/640
* Standardize .github files to .yaml suffix by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/641
* ✨ feat(annotations): auto-remap internal type paths via intersphinx by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/644
* ✨ feat(overloads): add opt-out control for overload rendering by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/645
* 🐛 fix(resolver): resolve forward refs in nested attrs classes by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/646


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.8.0...3.9.0

#### [`3.9.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.1)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(intersphinx): access inventory dict directly by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/647


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.0...3.9.1

#### [`3.9.2`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.2)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(intersphinx): handle objects without __qualname__ by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/648


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.1...3.9.2

#### [`3.9.3`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.3)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(intersphinx): exclude builtin type aliases from mapping by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/650


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.2...3.9.3

#### [`3.9.4`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.4)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(stubs): strip all suffixes for extension modules by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/652


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.3...3.9.4

#### [`3.9.5`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.5)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(stubs): resolve stub imports for type hint evaluation by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/654


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.4...3.9.5

#### [`3.9.6`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.6)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(stubs): resolve stub type hints for C/Rust extensions by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/655


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.5...3.9.6

#### [`3.9.7`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.7)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(resolver): resolve NamedTuple hints from class by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/657


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.6...3.9.7

#### [`3.9.8`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.8)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(docstring): preserve blank line after field list by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/659


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.7...3.9.8

#### [`3.9.9`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.9)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(stubs): resolve relative imports in .pyi stubs by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/663


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.8...3.9.9

#### [`3.9.10`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.10)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(stubs): use __new__ param annotations not class vars by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/667
* 🐛 fix(stubs): prevent forward ref warnings from stub annotation pollution by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/668


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.9...3.9.10

#### [`3.9.11`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.11)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(stubs): resolve imports inside if-blocks in .pyi stubs by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/670
* 🐛 fix(stubs): evaluate stub-only definitions for annotation resolution by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/671


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.10...3.9.11

#### [`3.10.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.0)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🔒 ci(workflows): add zizmor security auditing by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/672
* ✨ feat(resolver): auto-inject :vartype: for annotated instance vars by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/678
* 🐛 fix(intersphinx): skip union aliases in type mapping by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/679


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.11...3.10.0

#### [`3.10.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.1)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(resolver): surface hints for @​no_type_check targets by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/681


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.0...3.10.1

#### [`3.10.2`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.2)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(ivar): tolerate malformed :ivar field entries by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/684


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.1...3.10.2

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`46728a27`](https://github.com/kdeldycke/meta-package-manager/commit/46728a27fcb4bcf2642a1c6c3bef9901adb849d7) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/46728a27fcb4bcf2642a1c6c3bef9901adb849d7/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/46728a27fcb4bcf2642a1c6c3bef9901adb849d7/.github/workflows/autofix.yaml) |
| **Run** | [#2953.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/25954586425) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.4`