### PR TITLE
Fix README CLI parameter anchors

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,20 +39,20 @@ $ uvx meta-package-manager
 
 <img align="right" width="30%" height="30%" src="https://raw.githubusercontent.com/kdeldycke/meta-package-manager/main/docs/assets/mpm-managers-cli.png"/>
 
-- Inventory and list all [package managers](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#managers) available on the system.
+- Inventory and list all [package managers](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-managers) available on the system.
 - Supports macOS, Linux and Windows.
 - [Standalone executables](#executables) for Linux, macOS and Windows.
-- [List installed packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#installed).
-- [List duplicate installed packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#duplicates).
-- [Search for packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#search).
-- [Install a package](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#install).
-- [Remove a package](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#remove).
-- [List outdated packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#outdated).
-- [Sync local package infos](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#sync).
-- [Upgrade all outdated packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#upgrade).
-- [Backup list of installed packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#backup) to TOML file.
-- [Restore/install list of packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#restore) from TOML files.
-- [Software Bill of Materials](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#sbom): export installed packages to [SPDX](https://spdx.dev) and [CycloneDX](https://cyclonedx.org) SBOM files.
+- [List installed packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-installed).
+- [List duplicate installed packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-installed-duplicates-installed-duplicates).
+- [Search for packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-search).
+- [Install a package](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-install).
+- [Remove a package](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-remove).
+- [List outdated packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-outdated).
+- [Sync local package infos](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-sync).
+- [Upgrade all outdated packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-upgrade).
+- [Backup list of installed packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-backup) to TOML file.
+- [Restore/install list of packages](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-restore) from TOML files.
+- [Software Bill of Materials](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm-sbom): export installed packages to [SPDX](https://spdx.dev) and [CycloneDX](https://cyclonedx.org) SBOM files.
 - Pin-point commands to a [subset of package managers](https://kdeldycke.github.io/meta-package-manager/usecase.html) (include/exclude selectors).
 - Support plain, versioned and [purl](https://github.com/package-url/purl-spec) package specifiers.
 - Export output to [JSON or user-friendly tables](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html#mpm).


### PR DESCRIPTION
## Summary

Fixes the stale `cli-parameters.html` fragments used in the README feature list.

The README is included by `docs/index.md`, so these replacements also clear the same generated docs/index fragment failures reported by linkcheck.

## Verification

Ran a targeted fragment check against the published `cli-parameters.html` page:

```text
checked_fragments= 13
unique_fragments= 13
missing= []
```

Scope is intentionally limited to the internal `cli-parameters.html` anchors from #1785. I left unrelated external 403/404/timeouts alone.
