### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/base.py
+++ b/meta_package_manager/base.py
@@ -790,9 +790,7 @@ class PackageManager(metaclass=MetaPackageManager):
                 raise
             logging.debug(f"Spawned PID {proc.pid}: {clean_args[0]}.")
             try:
-                logging.debug(
-                    f"Waiting for PID {proc.pid} (timeout={self.timeout}s)."
-                )
+                logging.debug(f"Waiting for PID {proc.pid} (timeout={self.timeout}s).")
                 stdout, stderr = proc.communicate(timeout=self.timeout)
                 logging.debug(
                     f"PID {proc.pid} exited {proc.returncode}; "


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`be3758d4`](https://github.com/kdeldycke/meta-package-manager/commit/be3758d4328087bbe17c477829d63a2a5a677265) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/be3758d4328087bbe17c477829d63a2a5a677265/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/be3758d4328087bbe17c477829d63a2a5a677265/.github/workflows/autofix.yaml) |
| **Run** | [#2961.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/26244454235) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.4`