### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -237,14 +237,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-17`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click](https://pypi.org/project/click/) | [`8.3.3` → `8.4.0`](https://github.com/pallets/click/compare/8.3.3...8.4.0) | 2026-05-17 |

### Release notes

<details>
<summary><code>click</code></summary>

#### [`8.4.0`](https://github.com/pallets/click/releases/tag/8.4.0)

This is the Click 8.4.0 feature release. A feature release may include new features, remove previously deprecated code, add new deprecation, or introduce potentially breaking changes.

We encourage everyone to upgrade. You can read more about our [Version Support Policy][version] on our website.

[version]: https://palletsprojects.com/versions

PyPI: https://pypi.org/project/click/8.4.0/
Changes:  https://click.palletsprojects.com/page/changes/#version-8-4-0
Milestone https://redirect.github.com/pallets/click/milestone/30

-   `ParamType` typing improvements. #​3371

    -   :class:`ParamType` is now a generic abstract base class,
        parameterized by its converted value type.
    -   :meth:`~ParamType.convert` return types are narrowed on all
        concrete types (``str`` for :class:`STRING`, ``int`` for
        :class:`INT`, etc.).
    -   :meth:`~ParamType.to_info_dict` returns specific
        :class:`~typing.TypedDict` subclasses instead of
        ``dict[str, Any]``.
    -   :class:`CompositeParamType` and the number-range base are now
        generic with abstract methods.
-   Refactor ``convert_type`` to extract type inference into a private
    ``_guess_type`` helper, and add :func:`typing.overload` signatures.
    #​3372
-   `Parameter` typing improvements. #​2805

    -   :class:`Parameter` is now an abstract base class, making explicit
        that it cannot be instantiated directly.
    -   :attr:`Parameter.name` is now ``str`` instead of ``str | None``.
        When ``expose_value=False``, the name is set to ``""`` instead
        of ``None``.
    -   The ``ctx`` parameter of :meth:`Parameter.get_error_hint` is now
        typed as ``Context | None``, matching the runtime behavior.
-   Split string values from ``default_map`` for parameters with ``nargs > 1``
    or :class:`Tuple` type, matching environment variable behavior.
    #​2745 #​3364

... [Full release notes](https://github.com/pallets/click/releases/tag/8.4.0)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`c5c147a7`](https://github.com/kdeldycke/meta-package-manager/commit/c5c147a7792eb9ab3a4609db131abc68cbbfe242) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/c5c147a7792eb9ab3a4609db131abc68cbbfe242/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/c5c147a7792eb9ab3a4609db131abc68cbbfe242/.github/workflows/autofix.yaml) |
| **Run** | [#2977.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/26362184694) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.19.0`