### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -572,11 +572,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -2113,11 +2113,11 @@ wheels = [
 
 [[package]]
 name = "uritools"
-version = "6.1.1"
+version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/76/034508ab9280225ef1352f7916fef0fb126e5e18dd66069f44f3c1336533/uritools-6.1.1.tar.gz", hash = "sha256:579b75d9438431574df07746a3c1445991d07f4bae65b25cdc0f43967670fb61", size = 30636, upload-time = "2026-05-18T18:22:43.155Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/75/b1f0e26e0c080c2febdd3a98a752c9fbcf078778f60fe90ea489dc8226ed/uritools-6.1.2.tar.gz", hash = "sha256:fa60028843a8be651699a1ee2b399066eeaef349224b32a177efa4aeba463f00", size = 24189, upload-time = "2026-05-21T23:11:11.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/ee/e229501e079194baea67362b51790a4a0c36a86ce1124d1815a439780251/uritools-6.1.1-py3-none-any.whl", hash = "sha256:c390cf204db7f14637bb47a2a8f2cc0a813e0bc3d16b6bc58e87433fa76e875a", size = 11991, upload-time = "2026-05-18T18:22:41.326Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/3f/44a8c5de526ad21bd540015fd44987da69469ea9f51b7c9ac6a8b475a4a8/uritools-6.1.2-py3-none-any.whl", hash = "sha256:5682f8c58e96e379224fd72aec227a45432740c1fa860a06b3024d47c2968601", size = 11991, upload-time = "2026-05-21T23:11:10.002Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-22`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [idna](https://pypi.org/project/idna/) | [`3.15` → `3.16`](https://github.com/kjd/idna/compare/v3.15...v3.16) | 2026-05-22 |
| [uritools](https://pypi.org/project/uritools/) | [`6.1.1` → `6.1.2`](https://github.com/tkem/uritools/compare/v6.1.1...v6.1.2) | 2026-05-21 |

### Release notes

<details>
<summary><code>idna</code></summary>

[Changelog](https://redirect.github.com/kjd/idna/blob/master/HISTORY.md)

</details>

<details>
<summary><code>uritools</code></summary>

[Changelog](https://redirect.github.com/tkem/uritools/blob/master/CHANGELOG.rst)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e98b524b`](https://github.com/kdeldycke/meta-package-manager/commit/e98b524be3a8de26a1ddb4a116e462b4ffe35259) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/e98b524be3a8de26a1ddb4a116e462b4ffe35259/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/e98b524be3a8de26a1ddb4a116e462b4ffe35259/.github/workflows/autofix.yaml) |
| **Run** | [#2994.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/26616442516) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.24.0`