### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/brewfile.py
+++ b/meta_package_manager/brewfile.py
@@ -63,12 +63,10 @@ so that any third-party tap a downstream ``brew`` or ``cask`` entry references i
 registered before the install step runs.
 """
 
-DEFAULT_TAPS: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("homebrew", "core"),
-        ("homebrew", "cask"),
-    }
-)
+DEFAULT_TAPS: frozenset[tuple[str, str]] = frozenset({
+    ("homebrew", "core"),
+    ("homebrew", "cask"),
+})
 """Taps that ``brew`` enables by default. Never emitted as explicit ``tap`` lines."""
 
 

--- a/meta_package_manager/cli.py
+++ b/meta_package_manager/cli.py
@@ -81,7 +81,6 @@ from .config import (
 from .execution import CLIError, highlight_cli_name
 from .inventory import MAIN_PLATFORMS
 from .manager import PackageManager
-from .summary import package_counts, print_summary, sbom_summary
 from .package import packages_asdict
 from .pool import pool
 from .sbom import (
@@ -93,11 +92,13 @@ from .sbom import (
     spdx_support,
 )
 from .specifier import VERSION_SEP, Solver, Specifier
+from .summary import package_counts, print_summary, sbom_summary
 from .version import diff_versions
 
 if sys.version_info >= (3, 11):
-    import tomllib
     from enum import StrEnum
+
+    import tomllib
 else:
     import tomli as tomllib  # type: ignore[import-not-found]
     from backports.strenum import StrEnum  # type: ignore[import-not-found]
@@ -202,19 +203,17 @@ class Duration(ParamType):
     }
     """Number of seconds each recognized unit represents (empty unit means days)."""
 
-    _CALENDAR_UNITS = frozenset(
-        {
-            "mo",
-            "mon",
-            "month",
-            "months",
-            "y",
-            "yr",
-            "yrs",
-            "year",
-            "years",
-        }
-    )
+    _CALENDAR_UNITS = frozenset({
+        "mo",
+        "mon",
+        "month",
+        "months",
+        "y",
+        "yr",
+        "yrs",
+        "year",
+        "years",
+    })
     """Calendar units rejected for ambiguity: months span 28-31 days, years 365-366."""
 
     _FRIENDLY_PATTERN = re.compile(r"(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>[a-z]*)")
@@ -2150,7 +2149,8 @@ def sbom(ctx, spdx, export_format, overwrite, bundled, export_path):
                 # On Python 3.10, ``ExportFormat`` extends ``backports.strenum.StrEnum``
                 # whose typeshed stub omits ``__iter__``; iteration is provided by the
                 # ``EnumMeta`` metaclass at runtime.
-                supported = ", ".join(f.value for f in ExportFormat)  # type: ignore[attr-defined]
+                # type: ignore[attr-defined]
+                supported = ", ".join(f.value for f in ExportFormat)
                 logging.critical(
                     f"Cannot guess export format from {export_path.name!r}. "
                     f"Use --format to pick one of: {supported}."

--- a/meta_package_manager/config.py
+++ b/meta_package_manager/config.py
@@ -215,15 +215,13 @@ values. Safe to pop even if nothing was cached.
 """
 
 
-CONTRIBUTION_HINT_FIELDS: Final[frozenset[str]] = frozenset(
-    {
-        "cli_names",
-        "cli_search_path",
-        "requirement",
-        "version_cli_options",
-        "version_regexes",
-    }
-)
+CONTRIBUTION_HINT_FIELDS: Final[frozenset[str]] = frozenset({
+    "cli_names",
+    "cli_search_path",
+    "requirement",
+    "version_cli_options",
+    "version_regexes",
+})
 """Subset of :data:`OVERRIDABLE_FIELDS` whose override probably reflects a real
 upstream detection bug rather than a personal preference.
 
@@ -359,19 +357,15 @@ def format_contribution_hints(hints: list[ContributionHint]) -> str:
     ]
     for hint in hints:
         url = _build_issue_url(hint)
-        lines.extend(
-            (
-                f"  - {theme().invoked_command(hint.manager_id)}: "
-                f"override on `{hint.field}`",
-                f"    File a report: {url}",
-            )
-        )
-    lines.extend(
-        (
-            "",
-            "  (Disable with `--no-suggest-contribs` or `[mpm] suggest_contribs = false`.)",
-        )
-    )
+        lines.extend((
+            f"  - {theme().invoked_command(hint.manager_id)}: "
+            f"override on `{hint.field}`",
+            f"    File a report: {url}",
+        ))
+    lines.extend((
+        "",
+        "  (Disable with `--no-suggest-contribs` or `[mpm] suggest_contribs = false`.)",
+    ))
     return "\n".join(lines)
 
 

--- a/meta_package_manager/execution.py
+++ b/meta_package_manager/execution.py
@@ -57,7 +57,6 @@ from .version import parse_version
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
-
     from contextlib import AbstractContextManager
     from datetime import timedelta
 

--- a/meta_package_manager/managers/asdf.py
+++ b/meta_package_manager/managers/asdf.py
@@ -145,10 +145,11 @@ class ASDF(PackageManager):
             nodejs    20.10.0    missing
             ruby      3.3.0      missing
         """
-        current_versions: dict[str, str] = {}
-        for plugin, version, is_current in self._parse_list():
-            if is_current:
-                current_versions[plugin] = version
+        current_versions: dict[str, str] = {
+            plugin: version
+            for plugin, version, is_current in self._parse_list()
+            if is_current
+        }
 
         latest_output = self.run_cli("latest", "--all")
         for match in self._LATEST_REGEXP.finditer(latest_output):

--- a/meta_package_manager/managers/homebrew.py
+++ b/meta_package_manager/managers/homebrew.py
@@ -280,19 +280,26 @@ class Homebrew(PackageManager):
         installed_entries = formula.get("installed") or ()
         installed = installed_entries[-1] if installed_entries else {}
 
-        deps: list[Dependency] = []
-        for dep_name in formula.get("dependencies") or ():
-            deps.append(Dependency(target_id=dep_name, scope=DependencyScope.RUNTIME))
-        for dep_name in formula.get("build_dependencies") or ():
-            deps.append(Dependency(target_id=dep_name, scope=DependencyScope.BUILD))
-        for dep_name in formula.get("test_dependencies") or ():
-            deps.append(Dependency(target_id=dep_name, scope=DependencyScope.TEST))
-        for dep_name in formula.get("optional_dependencies") or ():
-            deps.append(Dependency(target_id=dep_name, scope=DependencyScope.OPTIONAL))
-        for dep_name in formula.get("recommended_dependencies") or ():
-            deps.append(
-                Dependency(target_id=dep_name, scope=DependencyScope.RECOMMENDED),
-            )
+        deps: list[Dependency] = [
+            Dependency(target_id=dep_name, scope=DependencyScope.RUNTIME)
+            for dep_name in formula.get("dependencies") or ()
+        ]
+        deps.extend(
+            Dependency(target_id=dep_name, scope=DependencyScope.BUILD)
+            for dep_name in formula.get("build_dependencies") or ()
+        )
+        deps.extend(
+            Dependency(target_id=dep_name, scope=DependencyScope.TEST)
+            for dep_name in formula.get("test_dependencies") or ()
+        )
+        deps.extend(
+            Dependency(target_id=dep_name, scope=DependencyScope.OPTIONAL)
+            for dep_name in formula.get("optional_dependencies") or ()
+        )
+        deps.extend(
+            Dependency(target_id=dep_name, scope=DependencyScope.RECOMMENDED)
+            for dep_name in formula.get("recommended_dependencies") or ()
+        )
 
         checksums: list[Checksum] = []
         # The bottle entry for the current platform carries a SHA256.
@@ -357,14 +364,15 @@ class Homebrew(PackageManager):
         dependency closure, a single ``url`` and ``sha256`` for the
         download, and a ``depends_on`` map limited to cross-cask edges.
         """
-        deps: list[Dependency] = []
         depends_on = cask.get("depends_on") or {}
-        for cask_dep in depends_on.get("cask") or ():
-            deps.append(Dependency(target_id=cask_dep, scope=DependencyScope.RUNTIME))
-        for formula_dep in depends_on.get("formula") or ():
-            deps.append(
-                Dependency(target_id=formula_dep, scope=DependencyScope.RUNTIME),
-            )
+        deps: list[Dependency] = [
+            Dependency(target_id=cask_dep, scope=DependencyScope.RUNTIME)
+            for cask_dep in depends_on.get("cask") or ()
+        ]
+        deps.extend(
+            Dependency(target_id=formula_dep, scope=DependencyScope.RUNTIME)
+            for formula_dep in depends_on.get("formula") or ()
+        )
 
         checksums: list[Checksum] = []
         sha = cask.get("sha256")

--- a/meta_package_manager/managers/zypper.py
+++ b/meta_package_manager/managers/zypper.py
@@ -137,7 +137,8 @@ class Zypper(PackageManager):
             return
 
         package_list = (
-            xmltodict.parse(output)
+            xmltodict
+            .parse(output)
             .get("stream", {})
             .get("search-result", {})
             .get("solvable-list", {})
@@ -209,7 +210,8 @@ class Zypper(PackageManager):
 
         package_list = []
         update_list = (
-            xmltodict.parse(output)
+            xmltodict
+            .parse(output)
             .get("stream", {})
             .get("update-status", {})
             .get("update-list", {})

--- a/meta_package_manager/sbom/cyclonedx.py
+++ b/meta_package_manager/sbom/cyclonedx.py
@@ -401,13 +401,11 @@ class CycloneDX(SBOM):
         dependency_edges = sum(
             len(dep.dependencies) for dep in self.document.dependencies
         )
-        base.update(
-            {
-                "components_in_document": len(self.document.components),
-                "external_bom_references": components_with_bom,
-                "dependency_edges": dependency_edges,
-            }
-        )
+        base.update({
+            "components_in_document": len(self.document.components),
+            "external_bom_references": components_with_bom,
+            "dependency_edges": dependency_edges,
+        })
         return base
 
     def export(self) -> str:

--- a/meta_package_manager/sbom/spdx.py
+++ b/meta_package_manager/sbom/spdx.py
@@ -51,29 +51,24 @@ from .base import SBOM, ExportFormat
 
 spdx_support = True
 try:
-    from spdx_tools.common.spdx_licensing import spdx_licensing  # type: ignore[import-untyped]
+    # type: ignore[import-untyped]
+    from spdx_tools.common.spdx_licensing import spdx_licensing
     from spdx_tools.spdx.model import (
         Actor,
         ActorType,
+        Checksum as SPDXChecksum,
+        ChecksumAlgorithm as SPDXChecksumAlgorithm,
         CreationInfo,
         Document,
         ExternalDocumentRef,
         ExternalPackageRef,
         ExternalPackageRefCategory,
+        Package as SPDXPackage,
         PackagePurpose,
         Relationship,
         RelationshipType,
         SpdxNoAssertion,
         SpdxNone,
-    )
-    from spdx_tools.spdx.model import (
-        Checksum as SPDXChecksum,
-    )
-    from spdx_tools.spdx.model import (
-        ChecksumAlgorithm as SPDXChecksumAlgorithm,
-    )
-    from spdx_tools.spdx.model import (
-        Package as SPDXPackage,
     )
     from spdx_tools.spdx.validation.document_validator import (
         validate_full_spdx_document,
@@ -152,7 +147,7 @@ def _parse_license_expression(expression: str):
         key = getattr(symbol, "key", None) or str(symbol)
         if key.startswith("LicenseRef-"):
             return None
-        if not spdx_licensing.validate(key).errors == []:
+        if spdx_licensing.validate(key).errors != []:
             return None
     return parsed
 
@@ -205,16 +200,14 @@ class SPDX(SBOM):
         """
         profile = get_profile()
         system_id = self.normalize_spdx_id(
-            "-".join(
-                (
-                    current_platform().name,
-                    profile["linux_dist_name"],
-                    profile["linux_dist_version"],
-                    profile["uname"]["system"],
-                    profile["uname"]["release"],
-                    profile["uname"]["machine"],
-                )
-            )
+            "-".join((
+                current_platform().name,
+                profile["linux_dist_name"],
+                profile["linux_dist_version"],
+                profile["uname"]["system"],
+                profile["uname"]["release"],
+                profile["uname"]["machine"],
+            ))
         )
 
         self.seen_ids = set()
@@ -338,14 +331,14 @@ class SPDX(SBOM):
                 package.purl.to_string(),
             )
         ]
-        for extra in metadata.extra_purls:
-            refs.append(
-                ExternalPackageRef(
-                    ExternalPackageRefCategory.PACKAGE_MANAGER,
-                    "purl",
-                    extra.to_string(),
-                )
+        refs.extend(
+            ExternalPackageRef(
+                ExternalPackageRefCategory.PACKAGE_MANAGER,
+                "purl",
+                extra.to_string(),
             )
+            for extra in metadata.extra_purls
+        )
         if metadata.cpe:
             refs.append(
                 ExternalPackageRef(
@@ -429,9 +422,12 @@ class SPDX(SBOM):
             rel_type = _SPDX_RELATIONSHIP_MAP.get(
                 dep.scope.value, RelationshipType.DEPENDS_ON
             )
-            self.pending_relationships.append(
-                (package_docid, manager.id, dep.target_id, rel_type)
-            )
+            self.pending_relationships.append((
+                package_docid,
+                manager.id,
+                dep.target_id,
+                rel_type,
+            ))
 
         # Pull rich data from an upstream per-package SBOM if present.
         if metadata.external_sbom_path is not None:
@@ -609,15 +605,13 @@ class SPDX(SBOM):
             for rel in self.document.relationships
             if "DEPENDENCY" in rel.relationship_type.name
         )
-        base.update(
-            {
-                "packages_in_document": in_doc,
-                "transitive_packages_merged": in_doc - inventory_count,
-                "merged_documents": len(self.merged_docs),
-                "relationships_total": len(self.document.relationships),
-                "dependency_relationships": dependency_count,
-            }
-        )
+        base.update({
+            "packages_in_document": in_doc,
+            "transitive_packages_merged": in_doc - inventory_count,
+            "merged_documents": len(self.merged_docs),
+            "relationships_total": len(self.document.relationships),
+            "dependency_relationships": dependency_count,
+        })
         return base
 
     def export(self) -> str:


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`8e51112f`](https://github.com/kdeldycke/meta-package-manager/commit/8e51112fc15343edf5219e9776381f3300b549f8) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/8e51112fc15343edf5219e9776381f3300b549f8/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/8e51112fc15343edf5219e9776381f3300b549f8/.github/workflows/autofix.yaml) |
| **Run** | [#3042.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/27595558879) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.25.1`