### PR TITLE
Format Markdown

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,22 +134,22 @@ These go under `[mpm.<subcommand>]` (or `[tool.mpm.<subcommand>]`):
 
 **`[mpm.dump]`** (also reachable as `[mpm.backup]`, `[mpm.lock]`, `[mpm.freeze]`, `[mpm.snapshot]`)
 
-| Key              | Type    | Default | Description                                                                                |
-| :--------------- | :------ | :------ | :----------------------------------------------------------------------------------------- |
-| `toml`           | boolean | `true`  | Emit a TOML manifest with one section per manager.                                         |
-| `brewfile`       | boolean | `false` | Emit a Brewfile instead of a TOML manifest (managers supported by `brew bundle` only).     |
-| `header`         | boolean | `true`  | Include a metadata + warning comment block at the top of the output.                       |
-| `overwrite`      | boolean | `false` | Allow overwriting an existing output file.                                                 |
-| `merge`          | boolean | `false` | TOML only. Add each new entry to an existing file.                                         |
-| `update_version` | boolean | `false` | TOML only. Update each existing entry with the version currently installed on the system.  |
+| Key              | Type    | Default | Description                                                                               |
+| :--------------- | :------ | :------ | :---------------------------------------------------------------------------------------- |
+| `toml`           | boolean | `true`  | Emit a TOML manifest with one section per manager.                                        |
+| `brewfile`       | boolean | `false` | Emit a Brewfile instead of a TOML manifest (managers supported by `brew bundle` only).    |
+| `header`         | boolean | `true`  | Include a metadata + warning comment block at the top of the output.                      |
+| `overwrite`      | boolean | `false` | Allow overwriting an existing output file.                                                |
+| `merge`          | boolean | `false` | TOML only. Add each new entry to an existing file.                                        |
+| `update_version` | boolean | `false` | TOML only. Update each existing entry with the version currently installed on the system. |
 
 **`[mpm.sbom]`**
 
-| Key         | Type    | Default    | Description                                                                                                  |
-| :---------- | :------ | :--------- | :----------------------------------------------------------------------------------------------------------- |
-| `spdx`      | boolean | `true`     | Use SPDX format (`false` for CycloneDX).                                                                     |
-| `bundled`   | boolean | `true`     | Bundled mode: query each manager for richer metadata and merge per-package upstream SBOMs into the aggregate. Set `false` for fast inventory snapshots (name, version, purl only). |
-| `overwrite` | boolean | `false`    | Allow overwriting an existing SBOM file.                                                                     |
+| Key         | Type    | Default | Description                                                                                                                                                                        |
+| :---------- | :------ | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spdx`      | boolean | `true`  | Use SPDX format (`false` for CycloneDX).                                                                                                                                           |
+| `bundled`   | boolean | `true`  | Bundled mode: query each manager for richer metadata and merge per-package upstream SBOMs into the aggregate. Set `false` for fast inventory snapshots (name, version, purl only). |
+| `overwrite` | boolean | `false` | Allow overwriting an existing SBOM file.                                                                                                                                           |
 
 ## Full example
 

--- a/docs/dump.md
+++ b/docs/dump.md
@@ -79,7 +79,7 @@ You used to work on macOS. Now you'd like to move to Linux. To reduce friction d
    $ mpm dump packages.toml
    ```
 
-1. On your brand new Linux distribution, restore all packages with:
+2. On your brand new Linux distribution, restore all packages with:
 
    ```shell-session
    $ mpm restore packages.toml
@@ -136,6 +136,6 @@ Brewfile's `flatpak` entry accepts a `with: ["remote_name"]` keyword for non-def
 
 ## See also
 
-- {doc}`sbom` &mdash; SPDX and CycloneDX SBOM exports for supply-chain inventory work.
-- {doc}`overrides` &mdash; per-manager `[mpm.managers.<id>]` config blocks and how to generate them with `mpm config-template`.
-- {doc}`cooldown` &mdash; release-age gates that complement the snapshot workflow on the install side.
+- {doc}`sbom` — SPDX and CycloneDX SBOM exports for supply-chain inventory work.
+- {doc}`overrides` — per-manager `[mpm.managers.<id>]` config blocks and how to generate them with `mpm config-template`.
+- {doc}`cooldown` — release-age gates that complement the snapshot workflow on the install side.

--- a/docs/duplicates.md
+++ b/docs/duplicates.md
@@ -75,5 +75,5 @@ Add arguments to `installed` command, or an `--installed` boolean flag to `searc
 
 ## See also
 
-- {doc}`dump` &mdash; snapshot the resolved installation set after deduplication.
-- {doc}`configuration` &mdash; pin a preferred manager order so duplicates resolve consistently across runs.
+- {doc}`dump` — snapshot the resolved installation set after deduplication.
+- {doc}`configuration` — pin a preferred manager order so duplicates resolve consistently across runs.

--- a/docs/install.md
+++ b/docs/install.md
@@ -615,7 +615,7 @@ $ mpm install --man | man --local-file -
 The full command tree is also pre-rendered as static `.1` files:
 
 - Bundled as `mpm-manpages.tar.gz` on every [GitHub release](https://github.com/kdeldycke/meta-package-manager/releases). Download, extract, and copy to `${MANPATH%%:*}/man1/` (typically `/usr/local/share/man/man1/`).
-- Rendered next to the HTML docs at <https://kdeldycke.github.io/meta-package-manager/man/>, with browser-viewable HTML siblings ([live index](cli-parameters.md#man-pages)).
+- Rendered next to the HTML docs at [https://kdeldycke.github.io/meta-package-manager/man/](https://kdeldycke.github.io/meta-package-manager/man/), with browser-viewable HTML siblings ([live index](cli-parameters.md#man-pages)).
 
 Downstream packagers can regenerate them from source as part of their build phase:
 

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -85,5 +85,5 @@ For screen readers, pass `--accessible` (or set `ACCESSIBLE=1` in the environmen
 
 ## See also
 
-- {doc}`dump` &mdash; richer TOML and Brewfile snapshots that preserve manager structure for replay.
-- {doc}`sbom` &mdash; SPDX/CycloneDX exports targeted at supply-chain inventory work rather than ad-hoc piping.
+- {doc}`dump` — richer TOML and Brewfile snapshots that preserve manager structure for replay.
+- {doc}`sbom` — SPDX/CycloneDX exports targeted at supply-chain inventory work rather than ad-hoc piping.

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -93,5 +93,5 @@ suggest_contribs = false
 
 ## See also
 
-- {doc}`configuration` &mdash; global `[mpm]` settings and configuration-file precedence rules.
-- {doc}`add-new-manager` &mdash; for contributors who want to upstream a new manager rather than override an existing one.
+- {doc}`configuration` — global `[mpm]` settings and configuration-file precedence rules.
+- {doc}`add-new-manager` — for contributors who want to upstream a new manager rather than override an existing one.

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -128,7 +128,7 @@ $ mpm --brew sbom > deep.spdx.json
 
 | Manager  | License | Homepage | Download URL | Checksums | Dependency graph | Per-package SBOM |
 | -------- | :-----: | :------: | :----------: | :-------: | :--------------: | :--------------: |
-| Homebrew |    ✓    |    ✓     |      ✓       |     ✓     |        ✓         |   ✓ (opt-in)     |
+| Homebrew |    ✓    |    ✓     |      ✓       |     ✓     |        ✓         |    ✓ (opt-in)    |
 | pip      |    ✓    |    ✓     |              |           |        ✓         |                  |
 | Others   |         |          |              |           |                  |                  |
 
@@ -152,5 +152,5 @@ Without the extra, `mpm sbom` exits with an explanatory error pointing at this i
 
 ## See also
 
-- {doc}`dump` &mdash; TOML manifest and Brewfile snapshots for re-installation workflows.
-- {doc}`cooldown` &mdash; release-age gates that complement the SBOM workflow on the install side.
+- {doc}`dump` — TOML manifest and Brewfile snapshots for re-installation workflows.
+- {doc}`cooldown` — release-age gates that complement the SBOM workflow on the install side.


### PR DESCRIPTION
### Description

Auto-formats Markdown files with [mdformat](https://github.com/hukkin/mdformat) and its plugins. See the [`format-markdown` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`6c5d4c4c`](https://github.com/kdeldycke/meta-package-manager/commit/6c5d4c4ce49f3873d1c535e96e54f006fa020154) |
| **Job** | [`format-markdown`](https://github.com/kdeldycke/meta-package-manager/blob/6c5d4c4ce49f3873d1c535e96e54f006fa020154/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/6c5d4c4ce49f3873d1c535e96e54f006fa020154/.github/workflows/autofix.yaml) |
| **Run** | [#3046.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/27666921448) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.25.1`