### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-click-extra = "2026-06-13T20:00:00Z"
+click-extra = "2026-06-14T00:00:00Z"
 
 [[package]]
 name = "accessible-pygments"
@@ -443,7 +443,7 @@ toml = [
 
 [[package]]
 name = "cyclonedx-python-lib"
-version = "11.7.0"
+version = "11.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "license-expression" },
@@ -452,9 +452,9 @@ dependencies = [
     { name = "sortedcontainers" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/0d/64f02d3fd9c116d6f50a540d04d1e4f2e3c487f5062d2db53733ddb25917/cyclonedx_python_lib-11.7.0.tar.gz", hash = "sha256:fb1bc3dedfa31208444dbd743007f478ab6984010a184e5bd466bffd969e936e", size = 1411174, upload-time = "2026-03-17T15:19:16.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/45/5ce2515e092656ada3959897681a24a7299f13638d4805de3d1fd9f91342/cyclonedx_python_lib-11.8.0.tar.gz", hash = "sha256:a8935b06dfe53d80efd47b5f6a202eb678cea00f2930e94e3710f2c1510166c9", size = 1422887, upload-time = "2026-06-04T10:38:27.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/09/fe0e3bc32bd33707c519b102fc064ad2a2ce5a1b53e2be38b86936b476b1/cyclonedx_python_lib-11.7.0-py3-none-any.whl", hash = "sha256:02fa4f15ddbba21ac9093039f8137c0d1813af7fe88b760c5dcd3311a8da2178", size = 513041, upload-time = "2026-03-17T15:19:14.369Z" },
+    { url = "https://files.pythonhosted.org/packages/57/af/333ad82adec8121dae568f7d094a3b08ba485340cf19fe10674f2db14774/cyclonedx_python_lib-11.8.0-py3-none-any.whl", hash = "sha256:a326b575acbb3aa1040986307a4ae282ff27f99ffcbdfdaaf8de10ee85e97f01", size = 523911, upload-time = "2026-06-04T10:38:26.248Z" },
 ]
 
 [package.optional-dependencies]
@@ -1028,7 +1028,7 @@ docs = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx-autodoc-typehints", version = "3.10.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-autodoc-typehints", version = "3.10.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-click" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1938,7 +1938,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.10.4"
+version = "3.10.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1946,9 +1946,9 @@ resolution-markers = [
 dependencies = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/aa/d676b736c126250e91fff6da35f14160eb85b3a5b75b076915b9f249a9f6/sphinx_autodoc_typehints-3.10.4.tar.gz", hash = "sha256:8fa06b4c92f4bd883928d9d38a7c676d94a05a170b7ee20084a1ad360d6b25ea", size = 79571, upload-time = "2026-05-31T16:08:19.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/88/f4698f838b8cc030f3df73cf529f96d7c9e6dd3e3ff40968b7fe4d86c748/sphinx_autodoc_typehints-3.10.5.tar.gz", hash = "sha256:a54dfab95a6b5e8601543d25474497e98ed59268ac0ab01b3daba9817cf9707e", size = 79721, upload-time = "2026-06-03T15:30:28.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/aa/cb936b1f0a741873d8841040d51e65a4888f99dd4a92f6122de8ad7c4c01/sphinx_autodoc_typehints-3.10.4-py3-none-any.whl", hash = "sha256:53f5273956497c96d44a149025a8f8eed2f3a0e8c36adec7fb09d8c02da2e11a", size = 40386, upload-time = "2026-05-31T16:08:17.606Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9a/98ba24ca28b4a4afbb5066805838c7e1149b8de1e6f5e02774e0f39f13db/sphinx_autodoc_typehints-3.10.5-py3-none-any.whl", hash = "sha256:7155748080735731c892d09b5128bc4e5303795691ca8515ccf333b1efd8d964", size = 40433, upload-time = "2026-06-03T15:30:26.892Z" },
 ]
 
 [[package]]
@@ -2298,11 +2298,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/44/c833e6b746ffb654e9abacf7ad6c2480a9c8c42e9637c1ae849964fb4dde/wcwidth-0.8.0.tar.gz", hash = "sha256:68a882ff6d14e3d14e0cae590b96a0551be64ce4905408112a8254434a1bdf69", size = 1305357, upload-time = "2026-06-05T21:19:35.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/17/c68b6cbcfeadbf420b3c3edaf8fda51335bc9c38732adb2d3ba8984dc607/wcwidth-0.8.0-py3-none-any.whl", hash = "sha256:8c75e6099cefd197c4bcc67a486f70b5dbc68f997c05f34a811d853910450d64", size = 324935, upload-time = "2026-06-05T21:19:33.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-06`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [cyclonedx-python-lib](https://pypi.org/project/cyclonedx-python-lib/) | [`11.7.0` → `11.8.0`](https://github.com/CycloneDX/cyclonedx-python-lib/compare/v11.7.0...v11.8.0) | 2026-06-04 |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.10.4` → `3.10.5`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.4...3.10.5) | 2026-06-03 |
| [wcwidth](https://pypi.org/project/wcwidth/) | [`0.7.0` → `0.8.0`](https://github.com/jquast/wcwidth/compare/0.7.0...0.8.0) | 2026-06-05 |

### Release notes

<details>
<summary><code>cyclonedx-python-lib</code></summary>

#### [`v11.8.0`](https://github.com/CycloneDX/cyclonedx-python-lib/releases/tag/v11.8.0)

## v11.8.0 (2026-06-04)

### Documentation

- Update CDX summary ([#​951](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/951), [`752b162`](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/commit/752b1620a23e319add81c505fe7197a2ae3cca06))

### Features

- Add support CycloneDX 1.7.1 & 1.6.2 & 1.5.1 ([#​985](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/985), [`303889b`](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/commit/303889ba2b47033ae693c1af8bff552664e1910c))

- Pull SPDX license IDs v1.1-3.28.0 ([#​986](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/986), [`42ff044`](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/commit/42ff04444fa054d86da2302bc62e1bffd3b397df))

---

## What's Changed
* chore: extract glob for pyupgrade to separate script for cross-platform compatibility by @​peschuster in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/950
* docs: update CDX summary by @​jkowalleck in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/951
* chore: fix test coverage reporting by @​jkowalleck in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/956
* chore(deps-dev): update tomli requirement from 2.3.0 to 2.4.1 by @​dependabot[bot] in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/954
* chore(release): use own GH app for releasing by @​jkowalleck in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/958
* chore(ci): pin GitHub Actions to immutable SHAs while preserving tag tracking by @​Copilot in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/961
* chore: add zizmor workflow to harden GitHub Actions security by @​Copilot in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/968
* Update PULL_REQUEST_TEMPLATE.md by @​jkowalleck in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/974

... [Full release notes](https://github.com/CycloneDX/cyclonedx-python-lib/releases/tag/v11.8.0)

</details>

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.10.5`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.5)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* process_signature: don't skip the first arg on bound instance methods by @​ilia-kats in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/705
* 🐛 fix(annotations): use class role for Ellipsis/NotImplementedType on 3.13+ by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/707

## New Contributors
* @​ilia-kats made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/705

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.4...3.10.5

</details>

<details>
<summary><code>wcwidth</code></summary>

#### [`0.8.0`](https://github.com/jquast/wcwidth/releases/tag/0.8.0)

* **New** support for Variation Selector 15 Emojis as narrow, #​211.
* **New** argument, ``term_program`` for `wcstwidth()`_, `width()`_, `clip()`_, `wrap()`_, `ljust()`_, `rjust()`_, and `center()`_.  ``False`` disables corrections; ``True`` auto-detects by ``TERM_PROGRAM`` or ``TERM``; string values accept canonical names matching `list_term_programs()`_.  `wcstwidth()`_ defaults to ``True``; all other functions default to ``False``.
* **Improved** performance on Python 3.15 using standard library iter_graphemes() #​206.
* **Improved** memory usage and import time for Python 3.15 using lazy imports #​221.
* **Bugfix** Invisible_Stacker viramas now form conjuncts (Burmese, Khmer, etc.) and change some Virama width calculations to match `jacobsandlund/uucode`_ (ghostty) #​223.
* **Updated** graphemes width maximum now 2, matching Ghostty, foot, and Windows Terminal #​224.

**Full Changelog**: https://redirect.github.com/jquast/wcwidth/compare/0.7.0...0.8.0

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`0e994e7d`](https://github.com/kdeldycke/meta-package-manager/commit/0e994e7da666118b92ef3339d03fa71119892bd7) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/0e994e7da666118b92ef3339d03fa71119892bd7/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/0e994e7da666118b92ef3339d03fa71119892bd7/.github/workflows/autofix.yaml) |
| **Run** | [#3024.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/27462884818) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.25.1`