### PR TITLE
Bump minor version to `v6.7.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`6.6.1.dev0` (unreleased)](https://github.com/kdeldycke/meta-package-manager/compare/v6.6.0...main)
+## [`6.7.0.dev0` (unreleased)](https://github.com/kdeldycke/meta-package-manager/compare/v6.6.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -8,8 +8,8 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.6809571
-version: 6.6.1.dev0
+version: 6.7.0.dev0
 # The release date is kept up to date by the external workflows. See:
 # https://github.com/kdeldycke/workflows/blob/33b704b489c1aa18b7b7efbf963e153e91e1c810/.github/workflows/changelog.yaml#L135-L137
-date-released: 2026-06-17
+date-released: 2026-06-18
 url: "https://github.com/kdeldycke/meta-package-manager"

--- a/meta_package_manager/__init__.py
+++ b/meta_package_manager/__init__.py
@@ -21,4 +21,4 @@ point lives in :py:mod:`meta_package_manager.cli`.
 
 from __future__ import annotations
 
-__version__ = "6.6.1.dev0"
+__version__ = "6.7.0.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "meta-package-manager"
-version = "6.6.1.dev0"
+version = "6.7.0.dev0"
 description = "🎁 wraps all package managers with a unifying CLI"
 readme = "readme.md"
 keywords = [
@@ -212,7 +212,7 @@ meta-package-manager = "meta_package_manager.__main__:main"
 
 [project.urls]
 "Homepage" = "https://github.com/kdeldycke/meta-package-manager"
-"Download" = "https://github.com/kdeldycke/meta-package-manager/releases/tag/v6.6.1.dev0"
+"Download" = "https://github.com/kdeldycke/meta-package-manager/releases/tag/v6.7.0.dev0"
 "Changelog" = "https://github.com/kdeldycke/meta-package-manager/blob/main/changelog.md"
 "Issues" = "https://github.com/kdeldycke/meta-package-manager/issues"
 "Repository" = "https://github.com/kdeldycke/meta-package-manager"
@@ -281,8 +281,8 @@ build-backend.module-root = ""
 product-name = "Meta Package Manager"
 file-description = "🎁 wraps all package managers with a unifying CLI"
 copyright = "Kevin Deldycke <kevin@deldycke.com> and contributors. Distributed under GPL-2.0-or-later license."
-file-version = "6.6.1"
-product-version = "6.6.1"
+file-version = "6.7.0"
+product-version = "6.7.0"
 # Each platform needs its native icon format (all rendered from icon.svg):
 # .icns for macOS, .ico for Windows, .png for Linux. Passing a non-native
 # image (like a PNG to --windows-icon-from-ico) makes Nuitka require the
@@ -353,7 +353,7 @@ run.source = [ "meta_package_manager" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "6.6.1.dev0"
+current_version = "6.7.0.dev0"
 allow_dirty = true
 ignore_missing_files = true
 # Parse versions with an optional .devN suffix (PEP 440).

--- a/uv.lock
+++ b/uv.lock
@@ -980,7 +980,7 @@ wheels = [
 
 [[package]]
 name = "meta-package-manager"
-version = "6.6.1.dev0"
+version = "6.7.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

### To bump version to `v6.7.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`eadb0422`](https://github.com/kdeldycke/meta-package-manager/commit/eadb04222fce47a7838521eace83f91e5254f5fe) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/meta-package-manager/blob/eadb04222fce47a7838521eace83f91e5254f5fe/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/eadb04222fce47a7838521eace83f91e5254f5fe/.github/workflows/changelog.yaml) |
| **Run** | [#1199.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/27744744310) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.26.0`