### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/cli.py
+++ b/meta_package_manager/cli.py
@@ -1155,7 +1155,6 @@ def installed(ctx, exact, duplicates, query):
     ``--exact`` requires a verbatim match on the package ID or name.
     """
     # Build-up a global dict of installed packages per manager.
-    installed_data = {}
     fields = (
         "id",
         "name",
@@ -1177,10 +1176,12 @@ def installed(ctx, exact, duplicates, query):
         )
         return _manager_result(manager, packages)
 
-    for manager_id, data in collect_from_managers(
-        ctx, "Listing", "Listed", managers, fetch
-    ):
-        installed_data[manager_id] = data
+    installed_data = {
+        manager_id: data
+        for manager_id, data in collect_from_managers(
+            ctx, "Listing", "Listed", managers, fetch
+        )
+    }
 
     # Filters out non-duplicate packages.
     if duplicates:
@@ -1271,7 +1272,6 @@ def outdated(ctx, exact, plugin_output, query):
     ``--exact`` requires a verbatim match on the package ID or name.
     """
     # Build-up a global list of outdated packages per manager.
-    outdated_data = {}
     fields = (
         "id",
         "name",
@@ -1292,10 +1292,12 @@ def outdated(ctx, exact, plugin_output, query):
         )
         return _manager_result(manager, packages)
 
-    for manager_id, data in collect_from_managers(
-        ctx, "Checking", "Checked", managers, fetch
-    ):
-        outdated_data[manager_id] = data
+    outdated_data = {
+        manager_id: data
+        for manager_id, data in collect_from_managers(
+            ctx, "Checking", "Checked", managers, fetch
+        )
+    }
 
     # Machine-friendly data rendering.
     print_serialized_and_exit(ctx, outdated_data)
@@ -1380,7 +1382,6 @@ def search(ctx, extended, exact, refilter, query):
         show_description = True
 
     # Build-up a global list of package matches per manager.
-    matches = {}
     fields = (
         "id",
         "name",
@@ -1402,10 +1403,12 @@ def search(ctx, extended, exact, refilter, query):
         )
         return _manager_result(manager, packages)
 
-    for manager_id, data in collect_from_managers(
-        ctx, "Searching", "Searched", managers, fetch
-    ):
-        matches[manager_id] = data
+    matches = {
+        manager_id: data
+        for manager_id, data in collect_from_managers(
+            ctx, "Searching", "Searched", managers, fetch
+        )
+    }
 
     # Machine-friendly data rendering.
     print_serialized_and_exit(ctx, matches)


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`93c2f482`](https://github.com/kdeldycke/meta-package-manager/commit/93c2f4822db0438689665df302eb6d0f25c9f27a) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/93c2f4822db0438689665df302eb6d0f25c9f27a/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/93c2f4822db0438689665df302eb6d0f25c9f27a/.github/workflows/autofix.yaml) |
| **Run** | [#3102.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/27936162506) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.28.1`