### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/cli.py
+++ b/meta_package_manager/cli.py
@@ -161,9 +161,7 @@ def _column_row_key(order: Sequence[int], row: Sequence[str | None]) -> tuple:
     Empty or ``None`` cells collate as the empty string. Mirrors the per-cell
     comparison click-extra's own table sorter applies.
     """
-    return tuple(
-        strip_ansi(cell).casefold() if (cell := row[i]) else "" for i in order
-    )
+    return tuple(strip_ansi(cell).casefold() if (cell := row[i]) else "" for i in order)
 
 
 def print_sorted_table(


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`544e7a8b`](https://github.com/kdeldycke/meta-package-manager/commit/544e7a8bf9242e03563f7f1cab83efeb8647bd32) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/544e7a8bf9242e03563f7f1cab83efeb8647bd32/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/544e7a8bf9242e03563f7f1cab83efeb8647bd32/.github/workflows/autofix.yaml) |
| **Run** | [#3110.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/27940108895) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.28.1`