### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -126,11 +126,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -443,7 +443,7 @@ toml = [
 
 [[package]]
 name = "cyclonedx-python-lib"
-version = "11.10.0"
+version = "11.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "license-expression" },
@@ -452,9 +452,9 @@ dependencies = [
     { name = "sortedcontainers" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/54/40d741cb605229cddcf9ec689b0fd401e39e2e70c2fe9cc728923b983b8e/cyclonedx_python_lib-11.10.0.tar.gz", hash = "sha256:d03d6ea271e26feaf123b8b1b34468a305f33a338c5763f56e397a8408f9b290", size = 1429036, upload-time = "2026-06-11T10:36:27.633Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/c9/5d0ccdd19bc7d8ab803b90695c1706aa2ea8529685d18e682dc2524d2630/cyclonedx_python_lib-11.11.0.tar.gz", hash = "sha256:4b3194db72b613717f2912447e67ab618c75ff7dcac6c4af3c0e9e1ac617c102", size = 1442983, upload-time = "2026-06-17T11:57:49.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/21/01c9b957ec3a778de86e010c1b54ea433ebf2fc50b810a3ca0ce8000782f/cyclonedx_python_lib-11.10.0-py3-none-any.whl", hash = "sha256:ffb9510b8d00a0896cfbe0a78b97c545d28f7d2a54e9d9dd5e5dc6e91ca9b375", size = 527798, upload-time = "2026-06-11T10:36:25.985Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f3/56ccb2884aaa3db5622368e5191a3384b15f35392aa93df8b2f508c660d2/cyclonedx_python_lib-11.11.0-py3-none-any.whl", hash = "sha256:3049fc83e06a059b5c5907a527625a8ed5073caab10607ed4c9e5503b590fd44", size = 528689, upload-time = "2026-06-17T11:57:47.358Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-18`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [certifi](https://pypi.org/project/certifi/) | `2026.5.20` → `2026.6.17` | 2026-06-17 |
| [cyclonedx-python-lib](https://pypi.org/project/cyclonedx-python-lib/) | [`11.10.0` → `11.11.0`](https://github.com/CycloneDX/cyclonedx-python-lib/compare/v11.10.0...v11.11.0) | 2026-06-17 |

### Release notes

<details>
<summary><code>cyclonedx-python-lib</code></summary>

#### [`v11.11.0`](https://github.com/CycloneDX/cyclonedx-python-lib/releases/tag/v11.11.0)

## v11.11.0 (2026-06-17)

### Bug Fixes

- Protocolpropertiestype enum case `5g-aka` for CycloneDX 1.7 ([#​1004](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/1004), [`bc97e1c`](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/commit/bc97e1c8fe08ff9b8895bb7908bec70bdaa815f0))

### Features

- `cryptoprimitive` enum cases for CycloneDX 1.7 ([#​1002](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/1002), [`788ced1`](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/commit/788ced146d2954669e88bf6d5af1054771245b27))

- `protocolpropertiestype` enum cases for CycloneDX 1.7 ([#​1003](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/1003), [`f9223d8`](https://redirect.github.com/CycloneDX/cyclonedx-python-lib/commit/f9223d8441af02a880feb1170e6549207ef551f3))

---

## What's Changed
* feat: `CryptoPrimitive` enum cases for CycloneDX 1.7 by @​jkowalleck in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/1002
* feat: `ProtocolPropertiesType` enum cases for CycloneDX 1.7 by @​jkowalleck in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/1003
* fix: ProtocolPropertiesType enum case `5g-aka` for CycloneDX 1.7 by @​jkowalleck in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/1004
* tests: check all enum completeness by @​jkowalleck in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/992
* refactor: simplify `contrib.bom.utils` by @​jkowalleck in https://redirect.github.com/CycloneDX/cyclonedx-python-lib/pull/1000


**Full Changelog**: https://redirect.github.com/CycloneDX/cyclonedx-python-lib/compare/v11.10.0...v11.11.0

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`6cdd6973`](https://github.com/kdeldycke/meta-package-manager/commit/6cdd69733ebb9e2645f530ec09cbbe5973f2084b) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/6cdd69733ebb9e2645f530ec09cbbe5973f2084b/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/6cdd69733ebb9e2645f530ec09cbbe5973f2084b/.github/workflows/autofix.yaml) |
| **Run** | [#3136.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/28149380652) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.30.0`