### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/cli.py
+++ b/meta_package_manager/cli.py
@@ -260,19 +260,17 @@ class Duration(ParamType):
     }
     """Number of seconds each recognized unit represents (empty unit means days)."""
 
-    _CALENDAR_UNITS = frozenset(
-        {
-            "mo",
-            "mon",
-            "month",
-            "months",
-            "y",
-            "yr",
-            "yrs",
-            "year",
-            "years",
-        }
-    )
+    _CALENDAR_UNITS = frozenset({
+        "mo",
+        "mon",
+        "month",
+        "months",
+        "y",
+        "yr",
+        "yrs",
+        "year",
+        "years",
+    })
     """Calendar units rejected for ambiguity: months span 28-31 days, years 365-366."""
 
     _FRIENDLY_PATTERN = re.compile(r"(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>[a-z]*)")
@@ -2067,21 +2065,19 @@ def upgrade(ctx, all, packages_specs):
             manager = pool.get(manager_id)
             if not cooldown_permits(manager):
                 continue
-            tasks.append(
-                (
+            tasks.append((
+                manager,
+                _package_task(
                     manager,
-                    _package_task(
-                        manager,
-                        spec,
-                        failures_lock,
-                        action=lambda m, s: m.upgrade(s.package_id, version=s.version),
-                        verb="upgrade",
-                        past="upgraded",
-                        prep="with",
-                        record_failure=lambda s: upgrade_failures.append(s.package_id),
-                    ),
-                )
-            )
+                    spec,
+                    failures_lock,
+                    action=lambda m, s: m.upgrade(s.package_id, version=s.version),
+                    verb="upgrade",
+                    past="upgraded",
+                    prep="with",
+                    record_failure=lambda s: upgrade_failures.append(s.package_id),
+                ),
+            ))
 
     collect_per_package("Upgrading", "Upgraded", tasks)
 
@@ -2170,21 +2166,19 @@ def remove(ctx, packages_specs):
         # as two.
         for manager_id in sorted(source_manager_ids):
             manager = pool.get(manager_id)
-            tasks.append(
-                (
+            tasks.append((
+                manager,
+                _package_task(
                     manager,
-                    _package_task(
-                        manager,
-                        spec,
-                        failures_lock,
-                        action=lambda m, s: m.remove(s.package_id),
-                        verb="remove",
-                        past="removed",
-                        prep="from",
-                        record_failure=lambda s: remove_failures.append(s.package_id),
-                    ),
-                )
-            )
+                    spec,
+                    failures_lock,
+                    action=lambda m, s: m.remove(s.package_id),
+                    verb="remove",
+                    past="removed",
+                    prep="from",
+                    record_failure=lambda s: remove_failures.append(s.package_id),
+                ),
+            ))
 
     collect_per_package("Removing", "Removed", tasks)
 
@@ -2629,25 +2623,19 @@ def restore(ctx, toml_files):
                     manager_id=manager.id,
                     version=str(version),
                 )
-                tasks.append(
-                    (
+                tasks.append((
+                    manager,
+                    _package_task(
                         manager,
-                        _package_task(
-                            manager,
-                            spec,
-                            failures_lock,
-                            action=lambda m, s: m.install(
-                                s.package_id, version=s.version
-                            ),
-                            verb="install",
-                            past="installed",
-                            prep="with",
-                            record_failure=lambda s: restore_failures.append(
-                                s.package_id
-                            ),
-                        ),
-                    )
-                )
+                        spec,
+                        failures_lock,
+                        action=lambda m, s: m.install(s.package_id, version=s.version),
+                        verb="install",
+                        past="installed",
+                        prep="with",
+                        record_failure=lambda s: restore_failures.append(s.package_id),
+                    ),
+                ))
 
     collect_per_package("Restoring", "Restored", tasks)
 

--- a/meta_package_manager/execution.py
+++ b/meta_package_manager/execution.py
@@ -71,6 +71,7 @@ from click_extra.spinner import Spinner
 from click_extra.testing import INDENT, PROMPT, args_cleanup
 from click_extra.theme import KO_GLYPH, OK_GLYPH, get_current_theme as theme
 from extra_platforms import UNIX, current_platform, is_any_windows
+from typing_extensions import Self
 
 from .version import parse_version
 
@@ -1248,7 +1249,7 @@ class OperationTrail:
         # Concurrent: a single aggregate spinner stands in for the muted per-call ones.
         self._enabled = None if progress else False
 
-    def __enter__(self) -> OperationTrail:
+    def __enter__(self) -> Self:
         if self.concurrent:
             for manager in self._managers:
                 manager.progress = False

--- a/tests/test_cli_concurrency.py
+++ b/tests/test_cli_concurrency.py
@@ -377,7 +377,8 @@ def test_per_package_tasks_of_one_manager_share_a_thread():
 
 def test_per_package_empty_is_a_noop():
     ctx = FakeContext(jobs=4)
-    assert collect_per_package("Doing", "Done", [], ctx=ctx) is None  # type: ignore[arg-type]
+    # type: ignore[arg-type]
+    assert collect_per_package("Doing", "Done", [], ctx=ctx) is None
 
 
 def test_per_package_finisher_when_spinner_shown(monkeypatch):

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -20,12 +20,12 @@ import pytest
 
 from meta_package_manager.capabilities import Operations
 from meta_package_manager.execution import (
-    CLIError,
     DEFAULT_TIMEOUT,
     MUTATING_TIMEOUT,
     OPERATION_TIMEOUTS,
     READ_ONLY_TIMEOUT,
     SPINNER_DELAY,
+    CLIError,
 )
 
 from .fake_manager import FakeManager


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`fc3351a9`](https://github.com/kdeldycke/meta-package-manager/commit/fc3351a95581d4dd3402b7ac04c6d646ed22daab) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/fc3351a95581d4dd3402b7ac04c6d646ed22daab/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/fc3351a95581d4dd3402b7ac04c6d646ed22daab/.github/workflows/autofix.yaml) |
| **Run** | [#3130.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/28085467929) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.29.0`