### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -99,11 +99,11 @@ wheels = [
 
 [[package]]
 name = "boltons"
-version = "25.0.0"
+version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/54/71a94d8e02da9a865587fb3fff100cb0fc7aa9f4d5ed9ed3a591216ddcc7/boltons-25.0.0.tar.gz", hash = "sha256:e110fbdc30b7b9868cb604e3f71d4722dd8f4dcb4a5ddd06028ba8f1ab0b5ace", size = 246294, upload-time = "2025-02-03T05:57:59.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/1f/60df922ae497d838c58b48caa518251e2c8e228d7fe93792fee69a3858d6/boltons-26.0.0.tar.gz", hash = "sha256:5566d6cfd5a1e873d8e8476496287a9f92979964611ad9a9cecb6b0ef29b1edd", size = 225129, upload-time = "2026-06-19T06:10:41.226Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/7f/0e961cf3908bc4c1c3e027de2794f867c6c89fb4916fc7dba295a0e80a2d/boltons-25.0.0-py3-none-any.whl", hash = "sha256:dc9fb38bf28985715497d1b54d00b62ea866eca3938938ea9043e254a3a6ca62", size = 194210, upload-time = "2025-02-03T05:57:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/00/01/4001033457f25ecdc2b1ffd513ca0b76200b9ea009dd64f6c1aad2dde133/boltons-26.0.0-py3-none-any.whl", hash = "sha256:ba077cac51b27532299634f87f5589b4080fa94a011b4d43a9247f775e9215c7", size = 195559, upload-time = "2026-06-19T06:10:39.865Z" },
 ]
 
 [[package]]
@@ -530,11 +530,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.0.0"
+version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/47/c761c7dcd279738db4c00a0afae6e0883100365e908ff4b79ddecddbaba1/extra_platforms-13.0.0.tar.gz", hash = "sha256:4f6870be428f6ffb38e880bfb9026c4c3f6432b527b374ac178dbabb1500c34a", size = 80874, upload-time = "2026-05-25T23:44:45.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4d/b793283bf4d002e7ffa8ad45c125f1f2306b238c0a641677d6b3a7397f1a/extra_platforms-13.0.1.tar.gz", hash = "sha256:2194e5cd8d58fbbba42d2810f15fea3da072020109998ca8d7ec938abcf59717", size = 80935, upload-time = "2026-06-18T15:58:55.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/f9/545a173986a41bd0b04765b8b4909347d8240ef576688434e67ba2642b7f/extra_platforms-13.0.0-py3-none-any.whl", hash = "sha256:08c28e9a1004960e090ec0ca56378910817b1ed1482013bbc3e91ab879bd431c", size = 84446, upload-time = "2026-05-25T23:44:47.263Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/f8/d9c3fb099faa51808f80255cc94df94f283be8a61e842459e8bb3e12dab0/extra_platforms-13.0.1-py3-none-any.whl", hash = "sha256:fd3b572504557e4b48323dc9704baf2fa939aed37dba5d9963a4aeffd3c9e325", size = 84499, upload-time = "2026-06-18T15:58:54.067Z" },
 ]
 
 [[package]]
@@ -1251,7 +1251,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1262,9 +1262,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1283,14 +1283,14 @@ wheels = [
 
 [[package]]
 name = "pytest-github-actions-annotate-failures"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/e1/8f2c242e6d75a26a8e5ddcc23f652a411e4aac3eedc4b923808ac0582685/pytest_github_actions_annotate_failures-0.4.0.tar.gz", hash = "sha256:77d6baa29c8c61c2dacc494fa76eb95a185f0ee61666714ac43fb12ea672d217", size = 10857, upload-time = "2026-03-02T18:57:40.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/74/9ee7377ed117e7084e7a04a8e5748239b5b2b99a58daa55bfb0d8b9a1a19/pytest_github_actions_annotate_failures-0.4.1.tar.gz", hash = "sha256:cce5ed29b57e8f454fcc4414f8c9aaa9bf8e40848cfcb444b13d7204e9fc9dcb", size = 11748, upload-time = "2026-06-18T17:04:33.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/bd/11809f5c78d5d8da2d0e004845d2382768bc20798b3e0988bca61efd349f/pytest_github_actions_annotate_failures-0.4.0-py3-none-any.whl", hash = "sha256:285fed86e16b0b7a8eac6acdcde31913798fb739b15ef5b86895b4f5e32bf237", size = 6039, upload-time = "2026-03-02T18:57:39.991Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/cc/962a57f364ffe32dea6400a5115c23b217146597b8a445f8a5c656343f0d/pytest_github_actions_annotate_failures-0.4.1-py3-none-any.whl", hash = "sha256:d117bba2f975a357f4e395a71bf1638b4bcf5558fd7e8ee56d2480a521af8e03", size = 6117, upload-time = "2026-06-18T17:04:32.932Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-19`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [boltons](https://pypi.org/project/boltons/) | [`25.0.0` → `26.0.0`](https://github.com/mahmoud/boltons/compare/25.0.0...26.0.0) | 2026-06-19 |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`13.0.0` → `13.0.1`](https://github.com/kdeldycke/extra-platforms/compare/v13.0.0...v13.0.1) | 2026-06-18 |
| [pytest](https://pypi.org/project/pytest/) | [`9.1.0` → `9.1.1`](https://github.com/pytest-dev/pytest/compare/9.1.0...9.1.1) | 2026-06-19 |
| [pytest-github-actions-annotate-failures](https://pypi.org/project/pytest-github-actions-annotate-failures/) | `0.4.0` → `0.4.1` | 2026-06-18 |

### Release notes

<details>
<summary><code>boltons</code></summary>

#### [`26.0.0`](https://github.com/mahmoud/boltons/releases/tag/26.0.0)

- Added [`funcutils.once`](https://boltons.readthedocs.io/en/latest/funcutils.html#boltons.funcutils.once) decorator for one-time function execution
- Added [`strutils.human_readable_list`](https://boltons.readthedocs.io/en/latest/strutils.html#boltons.strutils.human_readable_list) for formatting lists as human-readable strings
- Extended [`iterutils.partition`](https://boltons.readthedocs.io/en/latest/iterutils.html#boltons.iterutils.partition) to accept multiple predicates
- Added `cache` option to [`iterutils.remap`](https://boltons.readthedocs.io/en/latest/iterutils.html#boltons.iterutils.remap) and [`iterutils.research`](https://boltons.readthedocs.io/en/latest/iterutils.html#boltons.iterutils.research)
- Fixed [`iterutils.split`](https://boltons.readthedocs.io/en/latest/iterutils.html#boltons.iterutils.split) `maxsplit=0` wrapping source object instead of its values
- Fixed [`listutils.BarrelList`](https://boltons.readthedocs.io/en/latest/listutils.html#boltons.listutils.BarrelList) `insert()` raising `IndexError` on large negative indices (now clamps like built-in `list`)
- Fixed [`listutils.BarrelList`](https://boltons.readthedocs.io/en/latest/listutils.html#boltons.listutils.BarrelList) `sort()` with multiple internal lists
- Fixed [`dictutils.OrderedMultiDict`](https://boltons.readthedocs.io/en/latest/dictutils.html#boltons.dictutils.OrderedMultiDict) equality comparison against plain mappings
- Fixed [`strutils.bytes2human`](https://boltons.readthedocs.io/en/latest/strutils.html#boltons.strutils.bytes2human) rollover at exact powers of 1024
- Fixed [`tbutils.ParsedException.from_string`](https://boltons.readthedocs.io/en/latest/tbutils.html#boltons.tbutils.ParsedException) `IndexError` on truncated tracebacks
- Fixed [`tableutils.Table.to_text`](https://boltons.readthedocs.io/en/latest/tableutils.html#boltons.tableutils.Table) column sizing

... [Full release notes](https://github.com/mahmoud/boltons/releases/tag/26.0.0)

</details>

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.0.1`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.0.1)

- Add detection of macOS Golden Gate (v27.x).

**Full changelog**: [`v13.0.0...v13.0.1`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.0.0...v13.0.1)

</details>

<details>
<summary><code>pytest</code></summary>

#### [`9.1.1`](https://github.com/pytest-dev/pytest/releases/tag/9.1.1)

# pytest 9.1.1 (2026-06-19)

## Bug fixes

- [\#​14220](https://redirect.github.com/pytest-dev/pytest/issues/14220): Fixed a logic bug in `pytest.RaisesGroup` which would might cause it to display incorrect "It matches <span class="title-ref">FooError()</span> which was paired with <span class="title-ref">BarError</span>" messages.
- [\#​14591](https://redirect.github.com/pytest-dev/pytest/issues/14591): Fixed a regression in pytest 9.1.0 which caused overriding a parametrized fixture with an indirect <span class="title-ref">@​pytest.mark.parametrize</span> to fail with "duplicate parametrization of '\<fixture name\>'".
- [\#​14606](https://redirect.github.com/pytest-dev/pytest/issues/14606): Fixed `list-item` typing errors from mypy in `@pytest.mark.parametrize <pytest.mark.parametrize ref>` `argvalues` parameter.
- [\#​14608](https://redirect.github.com/pytest-dev/pytest/issues/14608): Fixed a regression in pytest 9.1.0 where `conftest.py` files located in `<invocation dir>/test*` were no longer loaded as initial conftests when invoked without arguments.
  This could cause certain hooks (like `pytest_addoption`) in these files to not fire.

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`424f99fb`](https://github.com/kdeldycke/meta-package-manager/commit/424f99fb041553e1de9926665c0371a5172b510c) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/meta-package-manager/blob/424f99fb041553e1de9926665c0371a5172b510c/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/424f99fb041553e1de9926665c0371a5172b510c/.github/workflows/autofix.yaml) |
| **Run** | [#3144.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/28246045871) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.30.0`