### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
 
 ## [`7.0.0` (2026-06-26)](https://github.com/kdeldycke/meta-package-manager/compare/v6.6.0...v7.0.0)
 
+> [!NOTE]
+> `7.0.0` is available on [🐍 PyPI](https://pypi.org/project/meta-package-manager/7.0.0/) and [🐙 GitHub](https://github.com/kdeldycke/meta-package-manager/releases/tag/v7.0.0).
+
 - **Breaking:** [mpm] Rename the `--allow-no-cooldown` flag to the `--require-cooldown-support`/`--allow-unsupported-managers` pair, and its `allow_no_cooldown` config to `require_cooldown_support` (default `true`).
 - **Breaking:** [mpm] The `sort_by` configuration option is now a list of fields, matching the repeatable `--sort-by`. Wrap an existing scalar value in brackets: `sort_by = "package_id"` becomes `sort_by = ["package_id"]`.
 - [pnpm] Add the pnpm package manager (`installed`, `outdated`, `search`, `install`, `upgrade`, `remove`, `cleanup`), enforcing `--cooldown` via pnpm's native `minimumReleaseAge` gate.


### PR DESCRIPTION
### Description

Fixes changelog release dates and updates availability admonitions.

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`9e9eee7d`](https://github.com/kdeldycke/meta-package-manager/commit/9e9eee7d6f73f0dc4d13a134d4896487dbe16953) |
| **Job** | [`fix-changelog`](https://github.com/kdeldycke/meta-package-manager/blob/9e9eee7d6f73f0dc4d13a134d4896487dbe16953/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/9e9eee7d6f73f0dc4d13a134d4896487dbe16953/.github/workflows/changelog.yaml) |
| **Run** | [#1274.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/28282123173) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.30.0`