### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/managers/pacman.py
+++ b/meta_package_manager/managers/pacman.py
@@ -16,9 +16,9 @@
 
 from __future__ import annotations
 
+import atexit
 import os
 import re
-import atexit
 import shutil
 import tempfile
 from datetime import datetime, timezone
@@ -42,7 +42,8 @@ if TYPE_CHECKING:
 
 
 _YAY_COOLDOWN_INIT_LUA = (
-    resources.files("meta_package_manager.managers")
+    resources
+    .files("meta_package_manager.managers")
     .joinpath("yay_cooldown.lua")
     .read_text(encoding="UTF-8")
 )

--- a/meta_package_manager/managers/pacstall.py
+++ b/meta_package_manager/managers/pacstall.py
@@ -104,8 +104,8 @@ class Pacstall(PackageManager):
 
             $ pacstall --list-upgrades
             Upgradable: 2
-            	neofetch @ pacstall-programs#master ( 7.1.0-2 -> 7.2.0-1 )
-            	neovim @ pacstall-programs#master ( 0.9.4-1 -> 0.10.0-1 )
+                neofetch @ pacstall-programs#master ( 7.1.0-2 -> 7.2.0-1 )
+                neovim @ pacstall-programs#master ( 0.9.4-1 -> 0.10.0-1 )
         """
         output = self.run_cli("--list-upgrades")
         for match in self._OUTDATED_REGEXP.finditer(output):

--- a/meta_package_manager/sbom/_network.py
+++ b/meta_package_manager/sbom/_network.py
@@ -58,6 +58,7 @@ except ImportError:
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
     from typing_extensions import Self
 
 

--- a/meta_package_manager/sbom/base.py
+++ b/meta_package_manager/sbom/base.py
@@ -152,9 +152,7 @@ class SBOM:
         # is over distinct ids, not over the per-purl lists.
         affected_purls = [p for p, v in self.vulnerabilities_by_purl.items() if v]
         unique_vuln_ids = {
-            vuln.id
-            for vulns in self.vulnerabilities_by_purl.values()
-            for vuln in vulns
+            vuln.id for vulns in self.vulnerabilities_by_purl.values() for vuln in vulns
         }
         return {
             "packages_total": sum(self.packages_per_manager.values()),

--- a/meta_package_manager/sbom/vulnerabilities.py
+++ b/meta_package_manager/sbom/vulnerabilities.py
@@ -358,9 +358,11 @@ def _extract_fixed_versions(affected: list) -> tuple[str, ...]:
     fixed: list[str] = []
     for entry in affected:
         for rng in entry.get("ranges", []) or []:
-            for event in rng.get("events", []) or []:
-                if "fixed" in event:
-                    fixed.append(event["fixed"])
+            fixed.extend(
+                event["fixed"]
+                for event in rng.get("events", []) or []
+                if "fixed" in event
+            )
     return tuple(dict.fromkeys(fixed))
 
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`7f2062d2`](https://github.com/kdeldycke/meta-package-manager/commit/7f2062d28154ba4bb8cbce76141345f2e602b35f) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/7f2062d28154ba4bb8cbce76141345f2e602b35f/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/7f2062d28154ba4bb8cbce76141345f2e602b35f/.github/workflows/autofix.yaml) |
| **Run** | [#3212.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/28817861403) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.31.0`