### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,9 @@
 
 ## [`7.1.0` (2026-07-07)](https://github.com/kdeldycke/meta-package-manager/compare/v7.0.1...v7.1.0)
 
+> [!NOTE]
+> `7.1.0` is available on [🐍 PyPI](https://pypi.org/project/meta-package-manager/7.1.0/) and [🐙 GitHub](https://github.com/kdeldycke/meta-package-manager/releases/tag/v7.1.0).
+
 - **Breaking:** [mpm] Split the `[sbom]` extra into `[sbom-offline]` (CycloneDX and SPDX document rendering) and `[sbom-online]` (the `--network` vulnerability lookups). `pip install meta-package-manager[sbom]` no longer resolves: use `[sbom-offline]` for the previous behavior, adding `[sbom-online]` for vulnerability scanning.
 - [mpm] Define brand-new package managers from the configuration file: a `[mpm.managers.<id>]` section declares a manager's platforms, CLI and version detection, and per-operation commands with `regex` or JSON parsers. Defined managers get `--<id>` / `--no-<id>` selectors and join the default set.
 - [mpm] Manager definitions load only from a trusted local config file (owned by you, not world-writable, never a remote `--config` URL), and a command-redirecting override (`pre_cmds`, `cli_names`, `cli_search_path`) read from an untrusted source now warns: see the new {doc}`security` page.


### PR DESCRIPTION
### Description

Fixes changelog release dates and updates availability admonitions.

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`abandoned-versions`](https://kdeldycke.github.io/repomatic/configuration.html#abandoned-versions)
- [`changelog.location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-location)
- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`012d2b38`](https://github.com/kdeldycke/meta-package-manager/commit/012d2b382d538b6b6b6870715b30d52048447d8e) |
| **Job** | [`fix-changelog`](https://github.com/kdeldycke/meta-package-manager/blob/012d2b382d538b6b6b6870715b30d52048447d8e/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/012d2b382d538b6b6b6870715b30d52048447d8e/.github/workflows/changelog.yaml) |
| **Run** | [#1357.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/28928739799) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.31.0`