### PR TITLE
Typo

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -126,7 +126,7 @@ Each entry under `[mpm.managers.<id>.operations]` declares one operation. Every 
 - `installed_version` (optional: some tools track no per-package version, like `swupd`'s Clear Linux bundles),
 - `latest_version` (required by `outdated`).
 
-Any `{token}` in an operation's `args` outside that operation's recognized placeholders is rejected at load time, so a typo like `{qeury}` surfaces immediately instead of reaching the tool as a literal argument.
+Any `{token}` in an operation's `args` outside that operation's recognized placeholders is rejected at load time, so a typo like `{query}` surfaces immediately instead of reaching the tool as a literal argument.
 
 ```{note}
 Version pinning is not expressible yet: `install` and `upgrade` on a config-defined manager always let the manager choose the version, and a `{version}` placeholder is not substituted. Native exact/extended search filtering is likewise not declarable, so `mpm` refilters `search` results itself.

--- a/meta_package_manager/config.py
+++ b/meta_package_manager/config.py
@@ -878,7 +878,7 @@ ALLOWED_ARG_PLACEHOLDERS: Final[Mapping[str, frozenset[str]]] = {
 """Placeholders each operation's ``args`` may reference.
 
 Operations absent from this mapping take no placeholder at all. Any ``{token}``
-outside the operation's set is rejected at parse time: a typoed ``{qeury}`` would
+outside the operation's set is rejected at parse time: a typoed ``{query}`` would
 otherwise reach the CLI as a literal argument and fail in silent, tool-specific ways.
 """
 

--- a/packaging/guix/meta-package-manager.scm
+++ b/packaging/guix/meta-package-manager.scm
@@ -31,7 +31,7 @@
              (commit (string-append "v" version))))
        (file-name (git-file-name name version))
        (sha256
-        (base32 "0m6r96q4kwglinchi6ir5adn8rpmz0wnzrs1l6m0gmxpcbgi3dnm"))))
+        (base32 "0m6r96q4kwglinchi6ir5and8rpmz0wnzrs1l6m0gmxpcbgi3dnm"))))
     (build-system pyproject-build-system)
     ;; Upstream builds with uv-build, which is not yet packaged for Guix; fall
     ;; back to setuptools.  Skip the SBOM CLI test, which pulls heavy optional

--- a/tests/test_manager_definition.py
+++ b/tests/test_manager_definition.py
@@ -178,12 +178,12 @@ def test_parse_definition_versionless_catalog_manager():
                 "platforms": ["linux"],
                 "operations": {
                     "search": {
-                        "args": ["s", "{qeury}"],
+                        "args": ["s", "{query}"],
                         "regex": r"^(?P<package_id>\S+)$",
                     },
                 },
             },
-            "unknown placeholder(s): {qeury}",
+            "unknown placeholder(s): {query}",
             id="typoed-placeholder",
         ),
         pytest.param(


### PR DESCRIPTION
### Description

Fixes typos detected by [typos](https://github.com/crate-ci/typos). See the [`fix-typos` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Manage false positives and customize spell-checking rules via [`[tool.typos]`](https://github.com/crate-ci/typos/blob/master/docs/reference.md) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`87e15c3a`](https://github.com/kdeldycke/meta-package-manager/commit/87e15c3a4a74dbc3ecb250124dca93606458dbbc) |
| **Job** | [`fix-typos`](https://github.com/kdeldycke/meta-package-manager/blob/87e15c3a4a74dbc3ecb250124dca93606458dbbc/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/87e15c3a4a74dbc3ecb250124dca93606458dbbc/.github/workflows/autofix.yaml) |
| **Run** | [#3232.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/28999421964) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`