### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check for new release
         id: check
         run: |
@@ -100,7 +100,7 @@ jobs:
       - name: Update package definition to latest release
         if: steps.check.outputs.skip != 'true'
         run: python3 packaging/guix/update.py
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         if: steps.check.outputs.skip != 'true'
       - name: Render PR body
         if: steps.check.outputs.skip != 'true'
@@ -151,7 +151,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: cachix/install-nix-action@v31
       - name: Check for new release
         id: check
@@ -177,7 +177,7 @@ jobs:
       - name: Update package definition to latest release
         if: steps.check.outputs.skip != 'true'
         run: python3 packaging/nix/update.py
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         if: steps.check.outputs.skip != 'true'
       - name: Render PR body
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/tests-install.yaml
+++ b/.github/workflows/tests-install.yaml
@@ -81,7 +81,7 @@ jobs:
           - windows-11-arm
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Pack
         shell: pwsh
         working-directory: packaging/choco/meta-package-manager
@@ -173,7 +173,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Guix
         run: >
           wget --quiet --output-document=guix-install.sh
@@ -220,7 +220,7 @@ jobs:
           - macos-26
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -279,7 +279,7 @@ jobs:
           - windows-2025
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Run CLI via pip
@@ -302,7 +302,7 @@ jobs:
           - windows-2025
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Run stable CLI via pipx
@@ -354,7 +354,7 @@ jobs:
           - windows-2025
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Run stable CLI

--- a/.github/workflows/tests-yay-cooldown.yaml
+++ b/.github/workflows/tests-yay-cooldown.yaml
@@ -37,7 +37,7 @@ jobs:
           pacman --sync --refresh --sysupgrade --noconfirm --needed
           base-devel curl git nodejs python sudo uv
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Write the integration test
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,8 +60,8 @@ jobs:
     outputs:
       metadata: ${{ steps.metadata.outputs.metadata }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Run repomatic metadata
         id: metadata
         run: >
@@ -97,7 +97,7 @@ jobs:
       # See: meta_package_manager/test_manager_homebrew.py::TestCask test.
       HOMEBREW_NO_INSTALL_FROM_API: "1"
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-tags: true
 
@@ -404,7 +404,7 @@ jobs:
           }
 
       - name: Install UV
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,
         # relying on transparent emulation. Native extensions with Rust (e.g., test-results-parser from codecov-cli)


### PR DESCRIPTION
### Description

Bumps SHA-pinned GitHub Actions (`uses: owner/repo@<sha> # vX.Y.Z`) to their latest releases that have cleared the stabilization cooldown, resolving each release tag to its commit SHA. See the [`sync-action-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-01` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/checkout](https://github.com/actions/checkout) | [`v6.0.2` → `v7.0.0`](https://github.com/actions/checkout/compare/v6.0.3...v7.0.0) | 2026-06-18 (a month ago) |
| [actions/checkout](https://github.com/actions/checkout) | [`v6.0.3` → `v7.0.0`](https://github.com/actions/checkout/compare/v6.0.3...v7.0.0) | 2026-06-18 (a month ago) |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | [`v7.6.0` → `v8.2.0`](https://github.com/astral-sh/setup-uv/compare/v8.1.0...v8.2.0) | 2026-06-03 (a month ago) |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | [`v8.1.0` → `v8.2.0`](https://github.com/astral-sh/setup-uv/compare/v8.1.0...v8.2.0) | 2026-06-03 (a month ago) |

### Release notes

<details>
<summary><code>actions/checkout</code></summary>

#### [`v7.0.0`](https://github.com/actions/checkout/releases/tag/v7.0.0)

## What's Changed
* block checking out fork pr for pull_request_target and workflow_run by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2454
* Bump actions/publish-immutable-action from 0.0.3 to 0.0.4 in the minor-actions-dependencies group across 1 directory by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2458
* Bump flatted from 3.3.1 to 3.4.2 by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2460
* Bump js-yaml from 4.1.0 to 4.2.0 by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2461
* Bump @​actions/core and @​actions/tool-cache and Remove uuid by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2459
* upgrade module to esm and update dependencies by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2463
* Bump the minor-npm-dependencies group across 1 directory with 3 updates by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2462
* getting ready for checkout v7 release by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2464
* update error wording by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2467

## New Contributors
* @​aiqiaoy made their first contribution in https://redirect.github.com/actions/checkout/pull/2454

**Full Changelog**: https://redirect.github.com/actions/checkout/compare/v6.0.3...v7.0.0

</details>

<details>
<summary><code>astral-sh/setup-uv</code></summary>

#### [`v8.2.0`](https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0)

## Changes

This release brings two new inputs and a few bug fixes.

### New inputs

Lets talk about the new inputs first.

#### quiet

Pretty simple. It turns of all `info` loggings. Useful if you use this in a composite action and are not interested in all the details.
In the upcoming releases we will add log groups to fully implement support for "less noise"

> [!NOTE]  
> Warnings and errors are always logged.

#### download-from-astral-mirror

In some cases you may want to directly use the fallback of checking for available versions and downloading releases from GitHub instead of using the astral.sh mirror. Setting `download-from-astral-mirror: false` allows you to do that.

### Bugfixes

When using the astral.sh mirror to query available versions and download releases (done by default) we now stop sending the GitHub token in the header. The mirror never looked at it but we shouldn't be handing out that data even if it is just a short lived token.
All other bugfixes try to limit the impact of failed GitHub queries due to retries and other faults.

We couldn't pinpoint all rootcauses yet but added more logging for error cases to track them down.

## 🐛 Bug fixes

- fix: report unexpected cache save failures @​eifinger (#​896)
- fix: report unexpected setup failures @​eifinger (#​895)
- fix: add timeout to fetch to prevent silent hangs @​eifinger-bot (#​883)
- Limit GitHub tokens to github.com download URLs @​zsol (#​878)
- increase libuv-workaround timeout to 100ms @​eifinger (#​880)

## 🚀 Enhancements

- Add quiet input to suppress info-level log output @​eifinger (#​898)
- feat: add `download-from-astral-mirror` input @​eifinger (#​897)

## 🧰 Maintenance

- docs: update dependabot rollup biome guidance @​eifinger (#​902)
- chore: update known checksums for 0.11.18 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​899)

... [Full release notes](https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0)

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Action | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | `8.2.0` | `8.3.2` | 2026-07-08 (a day ago) | 2026-07-16 (in a week) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`f3649949`](https://github.com/kdeldycke/meta-package-manager/commit/f3649949edfa5d6d8f2c5ffa9e9c66cc52792551) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/f3649949edfa5d6d8f2c5ffa9e9c66cc52792551/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/f3649949edfa5d6d8f2c5ffa9e9c66cc52792551/.github/workflows/autofix.yaml) |
| **Run** | [#3231.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/28994043211) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`