### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -505,7 +505,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: >
-          uvx --no-progress 'codecov-cli==11.2.7'
+          uvx --no-progress 'codecov-cli==11.2.8'
           --auto-load-params-from githubactions
           upload-process
           --git-service github
@@ -519,7 +519,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: >
-          uvx --no-progress 'codecov-cli==11.2.7'
+          uvx --no-progress 'codecov-cli==11.2.8'
           --auto-load-params-from githubactions
           upload-process
           --git-service github


### PR DESCRIPTION
### Description

Bumps npm and PyPI version literals embedded in workflow YAML (`npm install pkg@x`, `uvx '<pkg>==x'`) to their latest releases that have cleared the stabilization cooldown. See the [`sync-workflow-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-01` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.2.7` → `11.2.8` | 2026-03-26 (3 months ago) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`f3649949`](https://github.com/kdeldycke/meta-package-manager/commit/f3649949edfa5d6d8f2c5ffa9e9c66cc52792551) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/f3649949edfa5d6d8f2c5ffa9e9c66cc52792551/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/f3649949edfa5d6d8f2c5ffa9e9c66cc52792551/.github/workflows/autofix.yaml) |
| **Run** | [#3231.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/28994043211) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`