### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/managers/tazpkg.py
+++ b/meta_package_manager/managers/tazpkg.py
@@ -74,7 +74,11 @@ class Tazpkg(PackageManager):
             "$PKGS_DB/installed.info")
     """
 
-    version_cli_options = ("-F\t", '$1=="tazpkg"{print $2}', "/var/lib/tazpkg/installed.info")
+    version_cli_options = (
+        "-F\t",
+        '$1=="tazpkg"{print $2}',
+        "/var/lib/tazpkg/installed.info",
+    )
 
     version_regexes = (r"^(?P<version>[\d.]+)$",)
     """A bare integer Mercurial revision on cooking releases (``944``) or a dotted

--- a/packaging/guix/update.py
+++ b/packaging/guix/update.py
@@ -141,7 +141,7 @@ def get_git_base32(version: str) -> str:
 
 def get_current_version(scm_path: Path) -> str:
     """Extract the current version from the .scm file."""
-    content = scm_path.read_text()
+    content = scm_path.read_text(encoding="utf-8")
     match = re.search(r'\(version "([^"]+)"\)', content)
     if not match:
         msg = f"Cannot find version string in {scm_path}"
@@ -151,7 +151,7 @@ def get_current_version(scm_path: Path) -> str:
 
 def update_scm(scm_path: Path, version: str, base32_hash: str) -> None:
     """Update the version and hash in the .scm file."""
-    content = scm_path.read_text()
+    content = scm_path.read_text(encoding="utf-8")
     content = re.sub(
         r'\(version "[^"]+"\)',
         f'(version "{version}")',
@@ -162,7 +162,7 @@ def update_scm(scm_path: Path, version: str, base32_hash: str) -> None:
         f'(base32 "{base32_hash}")',
         content,
     )
-    scm_path.write_text(content)
+    scm_path.write_text(content, encoding="utf-8")
 
 
 def main() -> None:

--- a/packaging/nix/update.py
+++ b/packaging/nix/update.py
@@ -44,7 +44,7 @@ def get_latest_version() -> str:
 
 def get_current_version(nix_path: Path) -> str:
     """Extract the current version from the .nix file."""
-    content = nix_path.read_text()
+    content = nix_path.read_text(encoding="utf-8")
     match = re.search(r'version = "([^"]+)"', content)
     if not match:
         msg = f"Cannot find version string in {nix_path}"
@@ -79,7 +79,7 @@ def compute_sri_hash(url: str) -> str:
 
 def update_nix(nix_path: Path, version: str, sri_hash: str) -> None:
     """Update the version and hash in the .nix file."""
-    content = nix_path.read_text()
+    content = nix_path.read_text(encoding="utf-8")
     content = re.sub(
         r'version = "[^"]+"',
         f'version = "{version}"',
@@ -90,7 +90,7 @@ def update_nix(nix_path: Path, version: str, sri_hash: str) -> None:
         f'hash = "{sri_hash}"',
         content,
     )
-    nix_path.write_text(content)
+    nix_path.write_text(content, encoding="utf-8")
 
 
 def main() -> None:


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`90093059`](https://github.com/kdeldycke/meta-package-manager/commit/90093059c170ca7be5aa4040deda07784b1385d3) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/90093059c170ca7be5aa4040deda07784b1385d3/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/90093059c170ca7be5aa4040deda07784b1385d3/.github/workflows/autofix.yaml) |
| **Run** | [#3230.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/28960633982) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`