### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@
 
 ## [`7.2.0` (2026-07-09)](https://github.com/kdeldycke/meta-package-manager/compare/v7.1.0...v7.2.0)
 
+> [!NOTE]
+> `7.2.0` is available on [🐍 PyPI](https://pypi.org/project/meta-package-manager/7.2.0/) and [🐙 GitHub](https://github.com/kdeldycke/meta-package-manager/releases/tag/v7.2.0).
+
 - [mpm] Config-defined managers gain multi-binary support: a per-operation `cli` key runs an operation through a sibling binary, and `version_cli` probes an alternate binary for tool suites exposing no version flag.
 - [mpm] Config-defined managers gain privilege support: `sudo = true` marks an operation privileged, the new `default_sudo` field sets the manager-wide default, and both honor the global `--sudo`/`--no-sudo` policy.
 - [mpm] Manager definitions gain Brewfile export mappings: the new definition-only `brewfile_entry_type` and `brewfile_skip_warning` fields mirror the class attributes consumed by `mpm dump --brewfile`.


### PR DESCRIPTION
### Description

Fixes changelog release dates and updates availability admonitions.

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`abandoned-versions`](https://kdeldycke.github.io/repomatic/configuration.html#abandoned-versions)
- [`changelog.archive-location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-archive-location)
- [`changelog.location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-location)
- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`5b97eaa7`](https://github.com/kdeldycke/meta-package-manager/commit/5b97eaa7ea3cbb8faf68304acc9db7d478ae3557) |
| **Job** | [`fix-changelog`](https://github.com/kdeldycke/meta-package-manager/blob/5b97eaa7ea3cbb8faf68304acc9db7d478ae3557/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/5b97eaa7ea3cbb8faf68304acc9db7d478ae3557/.github/workflows/changelog.yaml) |
| **Run** | [#1370.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/29010489240) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`