### PR TITLE
Bump minor version to `v7.3.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`7.2.1.dev0` (unreleased)](https://github.com/kdeldycke/meta-package-manager/compare/v7.2.0...main)
+## [`7.3.0.dev0` (unreleased)](https://github.com/kdeldycke/meta-package-manager/compare/v7.2.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -8,8 +8,8 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.6809571
-version: 7.2.1.dev0
+version: 7.3.0.dev0
 # The release date is kept up to date by the external workflows. See:
 # https://github.com/kdeldycke/workflows/blob/33b704b489c1aa18b7b7efbf963e153e91e1c810/.github/workflows/changelog.yaml#L135-L137
-date-released: 2026-07-09
+date-released: 2026-07-15
 url: "https://github.com/kdeldycke/meta-package-manager"

--- a/meta_package_manager/__init__.py
+++ b/meta_package_manager/__init__.py
@@ -21,4 +21,4 @@ point lives in :py:mod:`meta_package_manager.cli`.
 
 from __future__ import annotations
 
-__version__ = "7.2.1.dev0"
+__version__ = "7.3.0.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "meta-package-manager"
-version = "7.2.1.dev0"
+version = "7.3.0.dev0"
 description = "🎁 wraps all package managers with a unifying CLI"
 readme = "readme.md"
 keywords = [
@@ -279,7 +279,7 @@ optional-dependencies.toml = [ "click-extra[toml]" ]
 optional-dependencies.xml = [ "click-extra[xml]" ]
 optional-dependencies.yaml = [ "click-extra[yaml]" ]
 urls.Changelog = "https://github.com/kdeldycke/meta-package-manager/blob/main/changelog.md"
-urls.Download = "https://github.com/kdeldycke/meta-package-manager/releases/tag/v7.2.1.dev0"
+urls.Download = "https://github.com/kdeldycke/meta-package-manager/releases/tag/v7.3.0.dev0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/meta-package-manager"
 urls.Issues = "https://github.com/kdeldycke/meta-package-manager/issues"
@@ -392,8 +392,8 @@ click-extra = { git = "https://github.com/kdeldycke/click-extra", branch = "main
 product-name = "Meta Package Manager"
 file-description = "🎁 wraps all package managers with a unifying CLI"
 copyright = "Kevin Deldycke <kevin@deldycke.com> and contributors. Distributed under GPL-2.0-or-later license."
-file-version = "7.2.1"
-product-version = "7.2.1"
+file-version = "7.3.0"
+product-version = "7.3.0"
 # Each platform needs its native icon format (all rendered from icon.svg):
 # .icns for macOS, .ico for Windows, .png for Linux. Passing a non-native
 # image (like a PNG to --windows-icon-from-ico) makes Nuitka require the
@@ -496,7 +496,7 @@ run.source = [ "meta_package_manager" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "7.2.1.dev0"
+current_version = "7.3.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/uv.lock
+++ b/uv.lock
@@ -1013,7 +1013,7 @@ wheels = [
 
 [[package]]
 name = "meta-package-manager"
-version = "7.2.1.dev0"
+version = "7.3.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

### To bump version to `v7.3.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`bf2e2331`](https://github.com/kdeldycke/meta-package-manager/commit/bf2e23317fc51b978512b549558aec7ffb8a2af9) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/meta-package-manager/blob/bf2e23317fc51b978512b549558aec7ffb8a2af9/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/bf2e23317fc51b978512b549558aec7ffb8a2af9/.github/workflows/changelog.yaml) |
| **Run** | [#1384.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/29443617239) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`