### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2294,11 +2294,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-02`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [typing-extensions](https://pypi.org/project/typing-extensions/) | [`4.15.0` → `4.16.0`](https://github.com/python/typing_extensions/compare/4.15.0...4.16.0) | 2026-07-02 (a week ago) |

### Release notes

<details>
<summary><code>typing-extensions</code></summary>

#### [`4.16.0rc1`](https://github.com/python/typing_extensions/releases/tag/4.16.0rc1)

- Make `typing_extensions.TypeAliasType`'s `__module__` attribute writable. Backport of CPython PR [#​149172](https://redirect.github.com/python/cpython/pull/149172).
- Fix setting of `__required_keys__` and `__optional_keys__` when inheriting keys with the same name.
- Add support for `AsyncIterator`, `io.Reader`, `io.Writer` and `os.PathLike` protocols as bases for other protocols.
- Fix incorrect behaviour on Python 3.9 and Python 3.10 that meant that calling `isinstance` with `typing_extensions.Concatenate[...]` or `typing_extensions.Unpack[...]` as the first argument could have a different result in some situations depending on whether or not a profiling function had been set using `sys.setprofile`. This affected both CPython and PyPy implementations. Patch by Brian Schubert.
- Fix `__init_subclass__()` behavior in the presence of multiple inheritance involving an `@deprecated`-decorated base class. Backport of CPython PR [#​138210](https://redirect.github.com/python/cpython/pull/138210) by Brian Schubert.
- Raise `TypeError` when attempting to subclass `typing_extensions.ParamSpec` on Python 3.9. The `typing` implementation has always raised an error, and the `typing_extensions` implementation has raised an error on Python 3.10+ since `typing_extensions` v4.6.0. Patch by Brian Schubert.
- Add the `bound`, `covariant`, `contravariant`, and `infer_variance` parameters to `TypeVarTuple`.
- Officially support the `bound`, `covariant`, `contravariant` and `infer_variance` parameters to `ParamSpec`. Improve the validation of these parameters at runtime.
- Rename `typing_extensions.Sentinel` to `typing_extensions.sentinel`, following the name that has been adopted for `builtins.sentinel` on Python 3.15. `typing_extensions.Sentinel` is retained as a soft-deprecated alias for backwards compatibility.
- Add support for pickling sentinels.
- Sentinels now preserve their identity when copied or deep-copied.

... [Full release notes](https://github.com/python/typing_extensions/releases/tag/4.16.0rc1)

#### [`4.16.0rc2`](https://github.com/python/typing_extensions/releases/tag/4.16.0rc2)

Changes since 4.16.0rc1:

- Avoid a `DeprecationWarning` when `deprecated` is applied to a coroutine function on Python 3.14.0.

Changes since 4.15.0:

- Make `typing_extensions.TypeAliasType`'s `__module__` attribute writable. Backport of CPython PR [#​149172](https://redirect.github.com/python/cpython/pull/149172).
- Fix setting of `__required_keys__` and `__optional_keys__` when inheriting keys with the same name.
- Add support for `AsyncIterator`, `io.Reader`, `io.Writer` and `os.PathLike` protocols as bases for other protocols.
- Fix incorrect behaviour on Python 3.9 and Python 3.10 that meant that calling `isinstance` with `typing_extensions.Concatenate[...]` or `typing_extensions.Unpack[...]` as the first argument could have a different result in some situations depending on whether or not a profiling function had been set using `sys.setprofile`. This affected both CPython and PyPy implementations. Patch by Brian Schubert.
- Fix `__init_subclass__()` behavior in the presence of multiple inheritance involving an `@deprecated`-decorated base class. Backport of CPython PR [#​138210](https://redirect.github.com/python/cpython/pull/138210) by Brian Schubert.
- Raise `TypeError` when attempting to subclass `typing_extensions.ParamSpec` on Python 3.9. The `typing` implementation has always raised an error, and the `typing_extensions` implementation has raised an error on Python 3.10+ since `typing_extensions` v4.6.0. Patch by Brian Schubert.
- Add the `bound`, `covariant`, `contravariant`, and `infer_variance` parameters to `TypeVarTuple`.
- Officially support the `bound`, `covariant`, `contravariant` and `infer_variance` parameters to `ParamSpec`. Improve the validation of these parameters at runtime.
- Rename `typing_extensions.Sentinel` to `typing_extensions.sentinel`, following the name that has been adopted for `builtins.sentinel` on Python 3.15. `typing_extensions.Sentinel` is retained as a soft-deprecated alias for backwards compatibility.

... [Full release notes](https://github.com/python/typing_extensions/releases/tag/4.16.0rc2)

#### [`4.16.0`](https://github.com/python/typing_extensions/releases/tag/4.16.0)

No changes since 4.16.0rc2.

Changes since 4.15.0:

- Make `typing_extensions.TypeAliasType`'s `__module__` attribute writable. Backport of CPython PR [#​149172](https://redirect.github.com/python/cpython/pull/149172).
- Fix setting of `__required_keys__` and `__optional_keys__` when inheriting keys with the same name.
- Add support for `AsyncIterator`, `io.Reader`, `io.Writer` and `os.PathLike` protocols as bases for other protocols.
- Fix incorrect behaviour on Python 3.9 and Python 3.10 that meant that calling `isinstance` with `typing_extensions.Concatenate[...]` or `typing_extensions.Unpack[...]` as the first argument could have a different result in some situations depending on whether or not a profiling function had been set using `sys.setprofile`. This affected both CPython and PyPy implementations. Patch by Brian Schubert.
- Fix `__init_subclass__()` behavior in the presence of multiple inheritance involving an `@deprecated`-decorated base class. Backport of CPython PR [#​138210](https://redirect.github.com/python/cpython/pull/138210) by Brian Schubert.
- Raise `TypeError` when attempting to subclass `typing_extensions.ParamSpec` on Python 3.9. The `typing` implementation has always raised an error, and the `typing_extensions` implementation has raised an error on Python 3.10+ since `typing_extensions` v4.6.0. Patch by Brian Schubert.
- Add the `bound`, `covariant`, `contravariant`, and `infer_variance` parameters to `TypeVarTuple`.
- Officially support the `bound`, `covariant`, `contravariant` and `infer_variance` parameters to `ParamSpec`. Improve the validation of these parameters at runtime.
- Rename `typing_extensions.Sentinel` to `typing_extensions.sentinel`, following the name that has been adopted for `builtins.sentinel` on Python 3.15. `typing_extensions.Sentinel` is retained as a soft-deprecated alias for backwards compatibility.
- Add support for pickling sentinels.

... [Full release notes](https://github.com/python/typing_extensions/releases/tag/4.16.0)

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window. Each becomes lockable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [charset-normalizer](https://pypi.org/project/charset-normalizer/) | `3.4.7` | `3.4.9` | 2026-07-07 (2 days ago) | 2026-07-14 (in 5 days) |
| [coverage](https://pypi.org/project/coverage/) | `7.14.3` | `7.15.0` | 2026-07-02 (a week ago) | 2026-07-09 (just now) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.0` | `3.12.1` | 2026-07-03 (6 days ago) | 2026-07-10 (in a day) |
| [sphinxcontrib-mermaid](https://pypi.org/project/sphinxcontrib-mermaid/) | `2.0.2` | `2.0.3` | 2026-07-08 (a day ago) | 2026-07-15 (in 6 days) |
| [wcmatch](https://pypi.org/project/wcmatch/) | `10.2` | `10.2.1` | 2026-07-02 (a week ago) | 2026-07-09 (just now) |

### ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Expires |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.3.0` | 2026-07-15 (in 6 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.1.0` | 2026-07-15 (in 6 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`5b97eaa7`](https://github.com/kdeldycke/meta-package-manager/commit/5b97eaa7ea3cbb8faf68304acc9db7d478ae3557) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/5b97eaa7ea3cbb8faf68304acc9db7d478ae3557/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/5b97eaa7ea3cbb8faf68304acc9db7d478ae3557/.github/workflows/autofix.yaml) |
| **Run** | [#3238.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/29010489305) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`