### PR TITLE
Format Python

### DIFF
--- a/meta_package_manager/bar_plugin_renderer.py
+++ b/meta_package_manager/bar_plugin_renderer.py
@@ -41,6 +41,7 @@ from unittest.mock import patch
 from boltons.iterutils import flatten
 from click_extra import echo
 from click_extra.table import TableFormat, render_table
+
 from .bar_plugin import MPMPlugin
 from .pool import pool
 

--- a/meta_package_manager/brewfile.py
+++ b/meta_package_manager/brewfile.py
@@ -63,12 +63,10 @@ so that any third-party tap a downstream ``brew`` or ``cask`` entry references i
 registered before the install step runs.
 """
 
-DEFAULT_TAPS: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("homebrew", "core"),
-        ("homebrew", "cask"),
-    }
-)
+DEFAULT_TAPS: frozenset[tuple[str, str]] = frozenset({
+    ("homebrew", "core"),
+    ("homebrew", "cask"),
+})
 """Taps that ``brew`` enables by default. Never emitted as explicit ``tap`` lines."""
 
 

--- a/meta_package_manager/cli.py
+++ b/meta_package_manager/cli.py
@@ -1061,18 +1061,16 @@ def managers(ctx):
                 if not manager.fresh:
                     version_infos += f" {manager.requirement}"
 
-        table.append(
-            {
-                "manager_id": getattr(theme(), "success" if manager.fresh else "error")(
-                    manager.id
-                ),
-                "manager_name": manager.name,
-                "supported": os_infos,
-                "cli": cli_infos,
-                "executable": theme().success(OK_GLYPH) if manager.executable else "",
-                "version": version_infos,
-            }
-        )
+        table.append({
+            "manager_id": getattr(theme(), "success" if manager.fresh else "error")(
+                manager.id
+            ),
+            "manager_name": manager.name,
+            "supported": os_infos,
+            "cli": cli_infos,
+            "executable": theme().success(OK_GLYPH) if manager.executable else "",
+            "version": version_infos,
+        })
 
     print_projected_table(ctx, MANAGERS_COLUMNS, table, ctx.obj.sort_by)
 
@@ -1342,17 +1340,13 @@ def outdated(ctx, exact, plugin_output, query):
                 info["installed_version"] if info["installed_version"] else "?",
                 info["latest_version"],
             )
-            table.append(
-                {
-                    "package_id": highlight_query(info["id"]) if info["id"] else "",
-                    "package_name": highlight_query(info["name"])
-                    if info["name"]
-                    else "",
-                    "manager_id": manager_id,
-                    "installed_version": installed_version,
-                    "latest_version": latest_version,
-                }
-            )
+            table.append({
+                "package_id": highlight_query(info["id"]) if info["id"] else "",
+                "package_name": highlight_query(info["name"]) if info["name"] else "",
+                "manager_id": manager_id,
+                "installed_version": installed_version,
+                "latest_version": latest_version,
+            })
 
     print_projected_table(ctx, OUTDATED_COLUMNS, table, ctx.obj.sort_by)
 
@@ -1438,19 +1432,17 @@ def search(ctx, extended, exact, refilter, query):
     table: list[dict[str, str | None]] = []
     for manager_id, matching_pkg in matches.items():
         for pkg in matching_pkg["packages"]:
-            table.append(
-                {
-                    "package_id": highlight_query(pkg["id"]) if pkg["id"] else "",
-                    "package_name": highlight_query(pkg["name"]) if pkg["name"] else "",
-                    "manager_id": manager_id,
-                    "latest_version": str(pkg["latest_version"])
-                    if pkg["latest_version"]
-                    else "?",
-                    "description": highlight_query(pkg.get("description"))
-                    if pkg.get("description")
-                    else "",
-                }
-            )
+            table.append({
+                "package_id": highlight_query(pkg["id"]) if pkg["id"] else "",
+                "package_name": highlight_query(pkg["name"]) if pkg["name"] else "",
+                "manager_id": manager_id,
+                "latest_version": str(pkg["latest_version"])
+                if pkg["latest_version"]
+                else "?",
+                "description": highlight_query(pkg.get("description"))
+                if pkg.get("description")
+                else "",
+            })
 
     default_ids = tuple(
         spec.id
@@ -1507,14 +1499,12 @@ def which(ctx, cli_names):
                 resolved = highlight_cli_name(found_cli.resolve(), cli_names)
                 assert resolved is not None
                 symlink = f"→ {resolved}"
-            table.append(
-                {
-                    "manager_id": manager.id,
-                    "priority": str(priority),
-                    "cli_path": highlight_cli_name(found_cli, cli_names),
-                    "symlink": symlink,
-                }
-            )
+            table.append({
+                "manager_id": manager.id,
+                "priority": str(priority),
+                "cli_path": highlight_cli_name(found_cli, cli_names),
+                "symlink": symlink,
+            })
     print_projected_table(ctx, WHICH_COLUMNS, table, ctx.obj.sort_by)
 
 
@@ -1761,21 +1751,19 @@ def _dispatch_sourced_operation(
             manager = pool.get(manager_id)
             if apply_cooldown and not cooldown_permits(manager):
                 continue
-            tasks.append(
-                (
+            tasks.append((
+                manager,
+                _package_task(
                     manager,
-                    _package_task(
-                        manager,
-                        spec,
-                        failures_lock,
-                        action=action,
-                        verb=verb,
-                        past=past,
-                        prep=prep,
-                        record_failure=lambda s: failures.append(s.package_id),
-                    ),
-                )
-            )
+                    spec,
+                    failures_lock,
+                    action=action,
+                    verb=verb,
+                    past=past,
+                    prep=prep,
+                    record_failure=lambda s: failures.append(s.package_id),
+                ),
+            ))
 
     collect_per_package(label, done_label, tasks)
 
@@ -2588,25 +2576,19 @@ def restore(ctx, toml_files):
                     manager_id=manager.id,
                     version=str(version),
                 )
-                tasks.append(
-                    (
+                tasks.append((
+                    manager,
+                    _package_task(
                         manager,
-                        _package_task(
-                            manager,
-                            spec,
-                            failures_lock,
-                            action=lambda m, s: m.install(
-                                s.package_id, version=s.version
-                            ),
-                            verb="install",
-                            past="installed",
-                            prep="with",
-                            record_failure=lambda s: restore_failures.append(
-                                s.package_id
-                            ),
-                        ),
-                    )
-                )
+                        spec,
+                        failures_lock,
+                        action=lambda m, s: m.install(s.package_id, version=s.version),
+                        verb="install",
+                        past="installed",
+                        prep="with",
+                        record_failure=lambda s: restore_failures.append(s.package_id),
+                    ),
+                ))
 
     collect_per_package("Restoring", "Restored", tasks)
 

--- a/meta_package_manager/pool.py
+++ b/meta_package_manager/pool.py
@@ -22,6 +22,7 @@ from functools import cached_property
 
 from boltons.iterutils import unique
 from click_extra import get_current_context
+
 from . import config
 from .capabilities import implements
 from .execution import warm_availability


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`54a053f7`](https://github.com/kdeldycke/meta-package-manager/commit/54a053f75ddccca33326f4c381ffb23c95a489a9) |
| **Job** | [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/54a053f75ddccca33326f4c381ffb23c95a489a9/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/54a053f75ddccca33326f4c381ffb23c95a489a9/.github/workflows/autofix.yaml) |
| **Run** | [#3248.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/29233208126) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`