### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,8 @@
 - [mpm] The PyPI keywords and the labeller file/content rules in `pyproject.toml` are now generated from the manager pool by `docs/docs_update.py`. Every bundled manager gains labeller coverage, definition-file globs are anchored on their full stem, and the `chocotaley` keyword typo is fixed.
 - [mpm] Bundled manager definitions now embed their version-probe and parser output samples in a `[samples]` table of their own TOML file; the test suite derives its checks from the shipped files instead of hardcoded per-manager fixtures.
 
+## [`7.2.1.dev0` (2026-07-09)](https://github.com/kdeldycke/meta-package-manager/compare/v7.2.0...v7.2.1.dev0)
+
 ## [`7.2.0` (2026-07-09)](https://github.com/kdeldycke/meta-package-manager/compare/v7.1.0...v7.2.0)
 
 > [!NOTE]


### PR DESCRIPTION
### Description

Fixes changelog release dates and updates availability admonitions.

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`abandoned-versions`](https://kdeldycke.github.io/repomatic/configuration.html#abandoned-versions)
- [`changelog.archive-location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-archive-location)
- [`changelog.location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-location)
- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`5876840f`](https://github.com/kdeldycke/meta-package-manager/commit/5876840f452d77ba60a61dc327dfa6d0d4a50d80) |
| **Job** | [`fix-changelog`](https://github.com/kdeldycke/meta-package-manager/blob/5876840f452d77ba60a61dc327dfa6d0d4a50d80/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/5876840f452d77ba60a61dc327dfa6d0d4a50d80/.github/workflows/changelog.yaml) |
| **Run** | [#1386.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/29443964058) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`