### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,7 +109,7 @@ jobs:
         env:
           VERSION: ${{ steps.check.outputs.version }}
         run: >
-          uvx --no-progress 'repomatic==7.1.0' pr-body
+          uvx --no-progress 'repomatic==7.2.0' pr-body
           --template-file .github/pr-templates/update-package-spec.md
           --template-arg channel=Guix
           --template-arg version="${VERSION}"
@@ -188,7 +188,7 @@ jobs:
         env:
           VERSION: ${{ steps.check.outputs.version }}
         run: >
-          uvx --no-progress 'repomatic==7.1.0' pr-body
+          uvx --no-progress 'repomatic==7.2.0' pr-body
           --template-file .github/pr-templates/update-package-spec.md
           --template-arg channel=Nix
           --template-arg version="${VERSION}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Run repomatic metadata
         id: metadata
         run: >
-          uvx --no-progress 'repomatic==7.1.0' metadata
+          uvx --no-progress 'repomatic==7.2.0' metadata
           --format github-json --output "$GITHUB_OUTPUT"
           test_matrix test_matrix_pr
 
@@ -505,7 +505,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: >
-          uvx --no-progress 'codecov-cli==11.2.8'
+          uvx --no-progress 'codecov-cli==11.3.1'
           --auto-load-params-from githubactions
           upload-process
           --git-service github
@@ -519,7 +519,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: >
-          uvx --no-progress 'codecov-cli==11.2.8'
+          uvx --no-progress 'codecov-cli==11.3.1'
           --auto-load-params-from githubactions
           upload-process
           --git-service github


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-09` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.2.8` → `11.3.1` | 2026-07-09 (a week ago) |
| [repomatic](https://pypi.org/project/repomatic/) | `7.1.0` → `7.2.0` |  |

### Release notes

<details>
<summary><code>repomatic</code></summary>

#### [`v7.2.0`](https://github.com/kdeldycke/repomatic/releases/tag/v7.2.0)

> [!NOTE]
> `7.2.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.2.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v7.2.0).

- **Breaking:** the `release-prep` command is renamed `prepare-release`, matching the job, template, and PR branch it drives; its module moves to `repomatic.prepare_release` and its class becomes `PrepareRelease`.
- **Breaking:** the `version-check` command is renamed `check-version`.
- **Breaking:** the vulnerability audit domain moves from `repomatic.uv` into the new `repomatic.vulnerable_deps` module, which also absorbs `repomatic.github.advisories`.
- **Breaking:** `repomatic.sponsor` moves under `repomatic.github`.
- **Breaking:** the PR-body helpers (`generate_pr_metadata_block`, `generate_refresh_tip`, `build_pr_body`) now take their CI context as arguments; `current_repo_url` is removed.
- **Breaking:** `build_expected_body` moves from `repomatic.github.release_sync` to `repomatic.changelog`.
- **Breaking:** the five `check_pat_*` probe functions are replaced by the `PAT_PERMISSION_PROBES` table and `probe_pat_permission`.
- **Breaking:** the workflow generation API (`generate_thin_caller`, `generate_workflow_header`, `generate_workflows`) drops its legacy `source_paths` argument; pass a `PathsSpec` instead.
- Add `cancel-runs`: cancels a branch's in-progress and queued workflow runs, replacing the bash block in `cancel-runs.yaml`; run listings now paginate past the first page.
- Add `[tool.repomatic] binaries.sync`: set to `false` to stop the release pipeline from committing the binaries catalog and scan records to the default branch.
- Add `sync-dep-sources`, a fifth `sync-deps` updater: once the release named by a git-tracked dependency's `.dev` floor ships on PyPI, it drops the `[tool.uv.sources]` override, tightens the floor, and freezes the adopted release through the cooldown. Disable with `[tool.repomatic] dep-sources.sync`.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v7.2.0)

</details>

## Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`3137b2a2`](https://github.com/kdeldycke/meta-package-manager/commit/3137b2a28edb7405a0911d8dc5f5ef691f21bddf)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/3137b2a28edb7405a0911d8dc5f5ef691f21bddf/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/3137b2a28edb7405a0911d8dc5f5ef691f21bddf/.github/workflows/autofix.yaml)
- **Run**: [#3265.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/29574351972)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.0`