### PR TITLE
Sync `bump-my-version` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -508,12 +508,6 @@ glob = "./**/__init__.py"
 ignore_missing_version = true
 
 [[tool.bumpversion.files]]
-# Update the version advertised in the Xbar/SwiftBar plugin header.
-filename = "./meta_package_manager/bar_plugin.py"
-search = "<xbar.version>{current_version}</xbar.version>"
-replace = "<xbar.version>{new_version}</xbar.version>"
-
-[[tool.bumpversion.files]]
 # Update version in [project] section. Anchored to a line start (regex) so it
 # does not also match version-suffixed keys like file-version/product-version
 # under [tool.nuitka], which contain `version = "X"` as a substring (their
@@ -548,9 +542,13 @@ search = "## [`{current_version}` (unreleased)]("
 replace = "## [`{new_version}` (unreleased)]("
 
 [[tool.bumpversion.files]]
-# Update the version in the citation file.
+# Update the version in the citation file. Anchored to a line start (regex) so
+# it does not also match the `cff-version:` schema field, which would otherwise
+# be overwritten with the package version on every bump as soon as the two
+# values coincide once.
 filename = "./citation.cff"
-search = "version: {current_version}"
+regex = true
+search = "(?m)^version: {current_version}"
 replace = "version: {new_version}"
 
 [[tool.bumpversion.files]]
@@ -559,6 +557,12 @@ filename = "./citation.cff"
 regex = true
 search = "date-released: \\d{{4}}-\\d{{2}}-\\d{{2}}"
 replace = "date-released: {utcnow:%Y-%m-%d}"
+
+[[tool.bumpversion.files]]
+# Update the version advertised in the Xbar/SwiftBar plugin header.
+filename = "./meta_package_manager/bar_plugin.py"
+search = "<xbar.version>{current_version}</xbar.version>"
+replace = "<xbar.version>{new_version}</xbar.version>"
 
 [tool.lychee]
 # ref: https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml


### PR DESCRIPTION
## Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`bumpversion.sync`](https://kdeldycke.github.io/repomatic/configuration.html#bumpversion-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-bumpversion`](https://kdeldycke.github.io/repomatic/workflows.html#sync-bumpversion-config-sync-bumpversion)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`3137b2a2`](https://github.com/kdeldycke/meta-package-manager/commit/3137b2a28edb7405a0911d8dc5f5ef691f21bddf)
- **Job**: [`sync-bumpversion`](https://github.com/kdeldycke/meta-package-manager/blob/3137b2a28edb7405a0911d8dc5f5ef691f21bddf/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/3137b2a28edb7405a0911d8dc5f5ef691f21bddf/.github/workflows/autofix.yaml)
- **Run**: [#3265.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/29574351972)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.0`