### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,9 @@
 
 ## [`7.3.0` (2026-07-17)](https://github.com/kdeldycke/meta-package-manager/compare/v7.2.0...v7.3.0)
 
+> [!NOTE]
+> `7.3.0` is available on [🐍 PyPI](https://pypi.org/project/meta-package-manager/7.3.0/) and [🐙 GitHub](https://github.com/kdeldycke/meta-package-manager/releases/tag/v7.3.0).
+
 - **Breaking:** [mpm] Move the declarative-manager schema, validation and class factory into the new `meta_package_manager.definitions` module, out of `meta_package_manager.config` (which keeps the loading policy: trust gate, override application, registration passes) and `meta_package_manager.manager` (which keeps the base class only).
 - **Breaking:** [mpm] Move the cross-manager fan-out machinery (`collect_from_managers`, `collect_per_package`, `OperationTrail`, the shared-lock families and the jobs policy) into the new `meta_package_manager.dispatch` module, out of `meta_package_manager.execution` (which keeps the single-subprocess engine).
 - **Breaking:** [mpm] Move the per-command column registries and the table-projection and serialization helpers into the new `meta_package_manager.tables` module, which also absorbs the `meta_package_manager.sorting` module and its `SortableField` vocabulary.


### PR DESCRIPTION
## Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`abandoned-versions`](https://kdeldycke.github.io/repomatic/configuration.html#abandoned-versions)
- [`changelog.archive-location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-archive-location)
- [`changelog.location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-location)
- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`fix-changelog`](https://kdeldycke.github.io/repomatic/workflows.html#fix-changelog-fix-changelog)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`27fb29dd`](https://github.com/kdeldycke/meta-package-manager/commit/27fb29ddb694ee47ddc7ac16827463e78ce3b963)
- **Job**: [`fix-changelog`](https://github.com/kdeldycke/meta-package-manager/blob/27fb29ddb694ee47ddc7ac16827463e78ce3b963/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/27fb29ddb694ee47ddc7ac16827463e78ce3b963/.github/workflows/changelog.yaml)
- **Run**: [#1413.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/29604690259)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.0`