### PR TITLE
Format Python

### DIFF
--- a/docs/docs_update.py
+++ b/docs/docs_update.py
@@ -466,7 +466,11 @@ def binaries_download_table() -> str:
             downloads[link_match["target"]] = link_match["url"]
 
     table = []
-    for os_label, os_id in (("Linux", "linux"), ("macOS", "macos"), ("Windows", "windows")):
+    for os_label, os_id in (
+        ("Linux", "linux"),
+        ("macOS", "macos"),
+        ("Windows", "windows"),
+    ):
         cells = [f"**{os_label}**"]
         for arch in ("arm64", "x64"):
             url = downloads.get(f"{os_id}-{arch}")

--- a/meta_package_manager/docstring_corpus.py
+++ b/meta_package_manager/docstring_corpus.py
@@ -327,9 +327,7 @@ def is_fixture(output: str) -> bool:
     return bool(output.strip())
 
 
-def literal_blocks(
-    cls: type, members: tuple[str, ...]
-) -> list[tuple[str, int, str]]:
+def literal_blocks(cls: type, members: tuple[str, ...]) -> list[tuple[str, int, str]]:
     """Return ``(member, index, block)`` for a class's replayable fixture blocks.
 
     A block qualifies when it carries sample output (:func:`is_fixture`). The

--- a/tests/test_docstring_corpus.py
+++ b/tests/test_docstring_corpus.py
@@ -128,9 +128,7 @@ def _fixtures():
         if any(
             is_fixture(split_session(b)) for b in blocks_by_member.get("outdated", ())
         ):
-            yield pytest.param(
-                manager, "outdated", None, id=f"{manager.id}-outdated"
-            )
+            yield pytest.param(manager, "outdated", None, id=f"{manager.id}-outdated")
 
 
 @pytest.mark.parametrize("manager, member, output", list(_fixtures()))
@@ -157,8 +155,7 @@ def test_documented_output_still_parses(manager, member, output, monkeypatch):
         manager.__dict__.pop("version", None)
         try:
             assert manager.version is not None, (
-                "version_regexes matched no parseable version in the documented "
-                "output"
+                "version_regexes matched no parseable version in the documented output"
             )
         finally:
             manager.__dict__.pop("version", None)


### PR DESCRIPTION
> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`format-python`](https://kdeldycke.github.io/repomatic/workflows.html#format-python-format-python)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`39f30568`](https://github.com/kdeldycke/meta-package-manager/commit/39f305688af96d311cec0f2ff23e1846a5507d13)
- **Job**: [`format-python`](https://github.com/kdeldycke/meta-package-manager/blob/39f305688af96d311cec0f2ff23e1846a5507d13/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/39f305688af96d311cec0f2ff23e1846a5507d13/.github/workflows/autofix.yaml)
- **Run**: [#3307.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/29740622142)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.0`