### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -511,11 +511,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.2.0"
+version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/cd/823e004612fa7ae3110a5a3e1383618c5a4198b0cdae47be74331122a397/extra_platforms-13.2.0.tar.gz", hash = "sha256:0f88c3ae147e175b9ce230874377a6f769b8e6bde8a5d8beee2ae77c60521a15", size = 83506, upload-time = "2026-07-15T21:20:13.155Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/c5/fae67f4681a664ad855b0cc219b89459f2144e144966b56abc2c63af2921/extra_platforms-13.3.1.tar.gz", hash = "sha256:1efefa780f0b97dce5d352f7873065988f7f23938af70456182b20474849d1c2", size = 86205, upload-time = "2026-07-17T14:02:38.235Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/9f/15543dea0bad0dab4aa9bdbe2ece05a383cdd12138fa03eac83e7c1e9c76/extra_platforms-13.2.0-py3-none-any.whl", hash = "sha256:178ad1cf567de078de58ce72c2f7049713980f14812d57b4a9c3250836446798", size = 86088, upload-time = "2026-07-15T21:20:11.62Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/77/aa1591668c391444dd4c30e29936cfaf42177ac9cc6073a681ca510bab02/extra_platforms-13.3.1-py3-none-any.whl", hash = "sha256:ffec89f6f5a983ea2be29970ee7144b2fa53a0fab381ce2b1ed447f4ad63d7a0", size = 89802, upload-time = "2026-07-17T14:02:36.684Z" },
 ]
 
 [[package]]
@@ -2275,11 +2275,11 @@ wheels = [
 
 [[package]]
 name = "tomlkit"
-version = "0.15.0"
+version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-17`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`13.2.0` → `13.3.1`](https://github.com/kdeldycke/extra-platforms/compare/v13.2.0...v13.3.1) | 2026-07-17 (a week ago) |
| [tomlkit](https://pypi.org/project/tomlkit/) | [`0.15.0` → `0.15.1`](https://github.com/python-poetry/tomlkit/compare/0.15.0...0.15.1) | 2026-07-17 (a week ago) |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.3.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0)

> [!NOTE]
> `13.3.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.3.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0).

- Deprecate the `TUMBLEWEED` platform: openSUSE Tumbleweed is now detected as `OPENSUSE`. `TUMBLEWEED`, `is_tumbleweed()` and the `skip_tumbleweed`/`unless_tumbleweed` decorators still resolve to their `OPENSUSE` counterparts with a `DeprecationWarning`, and will be removed in `14.0.0`.
- Detect all openSUSE release channels (Tumbleweed, Leap, Slowroll, MicroOS, ...) as `OPENSUSE`. Closes [#​619](https://redirect.github.com/kdeldycke/extra-platforms/issues/619)
- `Platform.info()` now reports the raw `os-release` ID of distribution sub-variants in its `distro_id` field (like `ol` or `opensuse-slowroll`) instead of aliasing it to the canonical platform ID.
- Rename `NON_OVERLAPPING_GROUPS` to `CANONICAL_GROUPS` and `EXTRA_GROUPS` to `NON_CANONICAL_GROUPS`, matching the `Group.canonical` vocabulary. The old names still resolve with a `DeprecationWarning`, and will be removed in `14.0.0`.
- `Trait.info()` is now implemented by the base class with identity metadata: custom `Trait` subclasses are no longer forced to override it.
- Rename the `ALL_CI` group to "All CI systems" and `ALL_AGENTS` to "All AI coding agents", aligning with the other "all" group names.
- `current_traits()` now returns an immutable `frozenset`: mutating the previously returned `set` corrupted its cache.
- `linux_info()` now returns `None` for missing fields instead of empty strings, like `macos_info()` and `windows_info()`.
- Fix pytest decorator skip reasons mangling acronyms and brand names ("Skip cI systems" is now "Skip All CI systems").
- Fix grammar and labels of the `current_*()` multiple-match errors ("Multiple CI matches:" is now "Multiple CI systems match:").
- Fix the `cff-version` schema field in `citation.cff` being overwritten with the package version on every version bump.

... [Full release notes](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0)

#### [`v13.3.1`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.1)

> [!NOTE]
> `13.3.1` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.3.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.3.1).

- Fix `test_current_funcs` failing under nested shells: extra shells backed by real ancestor processes (like a fish session running an OBS chroot build) are now accounted for. Addresses [#​619](https://redirect.github.com/kdeldycke/extra-platforms/issues/619)
- Document detection semantics on every trait page: which traits can match simultaneously (shells, platforms, terminals), which are exclusive (architectures, CI systems, agents), and how each `current_*()` function arbitrates or reports absences.
- Skip the whole test workflow on version-bump pushes and pull requests.
- Skip the package install checks on pull requests: they exercise the released package, not the change under review.
- Run the test suite in parallel outside CI too, by moving `--numprocesses=auto` and `--dist=loadgroup` to pytest `addopts`.

**Full changelog**: [`v13.3.0...v13.3.1`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.3.0...v13.3.1)

</details>

<details>
<summary><code>tomlkit</code></summary>

#### [`0.15.1`](https://github.com/python-poetry/tomlkit/releases/tag/0.15.1)

##### What's Changed
* Fix inline table separator after append by @​cyliu0 in https://redirect.github.com/python-poetry/tomlkit/pull/477
* chore(deps): bump idna from 3.7 to 3.15 in /docs by @​dependabot[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/481
* chore(deps-dev): bump idna from 3.7 to 3.15 by @​dependabot[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/480
* chore(deps): bump urllib3 from 2.5.0 to 2.7.0 in /docs by @​dependabot[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/475
* [pre-commit.ci] pre-commit autoupdate by @​pre-commit-ci[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/478
* [pre-commit.ci] pre-commit autoupdate by @​pre-commit-ci[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/484
* Fix duplicated comma when removing a middle inline table element by @​sarathfrancis90 in https://redirect.github.com/python-poetry/tomlkit/pull/486
* Add native __contains__ to Container, Table and InlineTable by @​tfoutrein in https://redirect.github.com/python-poetry/tomlkit/pull/487
* Make Source index-based instead of materializing a char list by @​tfoutrein in https://redirect.github.com/python-poetry/tomlkit/pull/489
* reject surrogate code points in \U unicode escapes by @​netliomax25-code in https://redirect.github.com/python-poetry/tomlkit/pull/493
* [pre-commit.ci] pre-commit autoupdate by @​pre-commit-ci[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/496
* Scan character runs in bulk while parsing by @​tfoutrein in https://redirect.github.com/python-poetry/tomlkit/pull/490
* Fix doubled comma when inserting into a comma-first array by @​gaoflow in https://redirect.github.com/python-poetry/tomlkit/pull/499
* reject tab characters in bare keys by @​netliomax25-code in https://redirect.github.com/python-poetry/tomlkit/pull/497
* reject non-hex digits in \u and \U escapes by @​netliomax25-code in https://redirect.github.com/python-poetry/tomlkit/pull/501

... [Full release notes](https://github.com/python-poetry/tomlkit/releases/tag/0.15.1)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [boltons](https://pypi.org/project/boltons/) | `26.0.0` | `26.1.0` | 2026-07-17 (a week ago) | 2026-07-24 (just now) |
| [bracex](https://pypi.org/project/bracex/) | `3.0` | `3.0.1` | 2026-07-20 (4 days ago) | 2026-07-27 (in 3 days) |
| [certifi](https://pypi.org/project/certifi/) | `2026.6.17` | `2026.7.22` | 2026-07-22 (2 days ago) | 2026-07-29 (in 5 days) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.10.0` | `4.11.0` | 2026-07-21 (3 days ago) | 2026-07-28 (in 4 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.8.4` | `2.9.1` | 2026-07-21 (3 days ago) | 2026-07-28 (in 4 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.1` | `3.13.0` | 2026-07-21 (3 days ago) | 2026-07-28 (in 4 days) |
| [sphinxcontrib-mermaid](https://pypi.org/project/sphinxcontrib-mermaid/) | `2.0.3` | `2.1.0` | 2026-07-18 (6 days ago) | 2026-07-25 (in a day) |
| [types-boltons](https://pypi.org/project/types-boltons/) | `25.0.0.20260612` | `26.1.0.20260724` | 2026-07-24 (just now) | 2026-07-31 (in a week) |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | `6.0.12.20260518` | `6.0.12.20260724` | 2026-07-24 (just now) | 2026-07-31 (in a week) |
| [uritools](https://pypi.org/project/uritools/) | `6.1.2` | `6.1.3` | 2026-07-23 (a day ago) | 2026-07-30 (in 6 days) |

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.6.0` | 2026-07-31 (in a week) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`98cb4e73`](https://github.com/kdeldycke/meta-package-manager/commit/98cb4e73a5c46e9f8def1b0d5e959e8180d07541)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/98cb4e73a5c46e9f8def1b0d5e959e8180d07541/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/98cb4e73a5c46e9f8def1b0d5e959e8180d07541/.github/workflows/autofix.yaml)
- **Run**: [#3333.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/30104629870)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`