### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -113,11 +113,11 @@ wheels = [
 
 [[package]]
 name = "boltons"
-version = "26.0.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7a/1f/60df922ae497d838c58b48caa518251e2c8e228d7fe93792fee69a3858d6/boltons-26.0.0.tar.gz", hash = "sha256:5566d6cfd5a1e873d8e8476496287a9f92979964611ad9a9cecb6b0ef29b1edd", size = 225129, upload-time = "2026-06-19T06:10:41.226Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/99/12bace94ae2ba961bdc46d49277ff15d38dba074bc3987b0c0b4355a37a7/boltons-26.1.0.tar.gz", hash = "sha256:5764468aba493b15995ed17f46a16789023f123ca2a62d491a9ce825c1cbe26c", size = 227393, upload-time = "2026-07-17T18:38:42.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/01/4001033457f25ecdc2b1ffd513ca0b76200b9ea009dd64f6c1aad2dde133/boltons-26.0.0-py3-none-any.whl", hash = "sha256:ba077cac51b27532299634f87f5589b4080fa94a011b4d43a9247f775e9215c7", size = 195559, upload-time = "2026-06-19T06:10:39.865Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ba/cea118a16647cc72633c5236f6f11a09ab76b136b1aaccfa0d7004958428/boltons-26.1.0-py3-none-any.whl", hash = "sha256:1d966b165805b83600b31af9f0db672e3b3313d9de438e22708a94ac5f4c93de", size = 196095, upload-time = "2026-07-17T18:38:41.164Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-17`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [boltons](https://pypi.org/project/boltons/) | [`26.0.0` → `26.1.0`](https://github.com/mahmoud/boltons/compare/26.0.0...26.1.0) | 2026-07-17 (a week ago) |

### Release notes

<details>
<summary><code>boltons</code></summary>

#### [`26.1.0`](https://github.com/mahmoud/boltons/releases/tag/26.1.0)

- Fixed `strutils.singularize` mangling words ending in 'ss'
- Fixed `fileutils.AtomicSaver` to accept `os.PathLike`
- Fixed `copy.copy`/`copy.deepcopy` collapsing `dictutils.OrderedMultiDict` values
- Sped up `strutils.MultiReplace` match lookup
- Fixed `setutils.IndexedSet` out-of-range negative indexing wrapping around
- Fixed `setutils.IndexedSet` slicing after removals

**Full Changelog**: https://redirect.github.com/mahmoud/boltons/compare/26.0.0...26.1.0

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [bracex](https://pypi.org/project/bracex/) | `3.0` | `3.0.1` | 2026-07-20 (4 days ago) | 2026-07-27 (in 3 days) |
| [certifi](https://pypi.org/project/certifi/) | `2026.6.17` | `2026.7.22` | 2026-07-22 (2 days ago) | 2026-07-29 (in 5 days) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.10.0` | `4.11.0` | 2026-07-21 (3 days ago) | 2026-07-28 (in 4 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.8.4` | `2.9.1` | 2026-07-21 (3 days ago) | 2026-07-28 (in 4 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.1` | `3.13.0` | 2026-07-21 (3 days ago) | 2026-07-28 (in 4 days) |
| [sphinxcontrib-mermaid](https://pypi.org/project/sphinxcontrib-mermaid/) | `2.0.3` | `2.1.0` | 2026-07-18 (6 days ago) | 2026-07-25 (in a day) |
| [types-boltons](https://pypi.org/project/types-boltons/) | `25.0.0.20260612` | `26.1.0.20260724` | 2026-07-24 (just now) | 2026-07-31 (in a week) |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | `6.0.12.20260518` | `6.0.12.20260724` | 2026-07-24 (just now) | 2026-07-31 (in a week) |
| [uritools](https://pypi.org/project/uritools/) | `6.1.2` | `6.1.3` | 2026-07-23 (a day ago) | 2026-07-30 (in 6 days) |

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.6.0` | 2026-07-31 (in a week) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`04bbf81f`](https://github.com/kdeldycke/meta-package-manager/commit/04bbf81fdffe14596e9186254dae7bb5c9453d96)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/04bbf81fdffe14596e9186254dae7bb5c9453d96/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/04bbf81fdffe14596e9186254dae7bb5c9453d96/.github/workflows/autofix.yaml)
- **Run**: [#3335.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/30119233353)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`