### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1203,11 +1203,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.10.0"
+version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/cd/4f25b2f95b23f5d2c9c1fe43e49841bff5800562149b2666afc09309aa8f/platformdirs-4.10.1.tar.gz", hash = "sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695", size = 31678, upload-time = "2026-07-18T03:53:43.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl", hash = "sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443", size = 22906, upload-time = "2026-07-18T03:53:42.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-18`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [platformdirs](https://pypi.org/project/platformdirs/) | [`4.10.0` → `4.10.1`](https://github.com/tox-dev/platformdirs/compare/4.10.0...4.10.1) | 2026-07-18 (a week ago) |

### Release notes

<details>
<summary><code>platformdirs</code></summary>

#### [`4.10.1`](https://github.com/tox-dev/platformdirs/releases/tag/4.10.1)

<!-- Release notes generated using configuration in .github/release.yaml at 4.10.1 -->

##### What's Changed
* 🐛 fix(windows): stop leaking memory on repeated folder lookups by @​gaborbernat in https://redirect.github.com/tox-dev/platformdirs/pull/507
* 🚀 ci(release): towncrier changelog + publish on tag push by @​gaborbernat in https://redirect.github.com/tox-dev/platformdirs/pull/509
* 📝 docs(changelog): rebuild against release history by @​gaborbernat in https://redirect.github.com/tox-dev/platformdirs/pull/510

**Full Changelog**: https://redirect.github.com/tox-dev/platformdirs/compare/4.10.0...4.10.1

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [bracex](https://pypi.org/project/bracex/) | `3.0` | `3.0.1` | 2026-07-20 (5 days ago) | 2026-07-27 (in 2 days) |
| [certifi](https://pypi.org/project/certifi/) | `2026.6.17` | `2026.7.22` | 2026-07-22 (3 days ago) | 2026-07-29 (in 4 days) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.10.1` | `4.11.0` | 2026-07-21 (4 days ago) | 2026-07-28 (in 3 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.8.4` | `2.9.1` | 2026-07-21 (4 days ago) | 2026-07-28 (in 3 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.1` | `3.13.0` | 2026-07-21 (4 days ago) | 2026-07-28 (in 3 days) |
| [sphinxcontrib-mermaid](https://pypi.org/project/sphinxcontrib-mermaid/) | `2.0.3` | `2.1.0` | 2026-07-18 (a week ago) | 2026-07-25 (just now) |
| [types-boltons](https://pypi.org/project/types-boltons/) | `25.0.0.20260612` | `26.1.0.20260724` | 2026-07-24 (a day ago) | 2026-07-31 (in 6 days) |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | `6.0.12.20260518` | `6.0.12.20260724` | 2026-07-24 (a day ago) | 2026-07-31 (in 6 days) |
| [uritools](https://pypi.org/project/uritools/) | `6.1.2` | `6.1.3` | 2026-07-23 (2 days ago) | 2026-07-30 (in 5 days) |

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.6.0` | 2026-07-31 (in 6 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`89aa3424`](https://github.com/kdeldycke/meta-package-manager/commit/89aa34249e0870c7d4761e63ddd0d5e5dff90484)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/89aa34249e0870c7d4761e63ddd0d5e5dff90484/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/89aa34249e0870c7d4761e63ddd0d5e5dff90484/.github/workflows/autofix.yaml)
- **Run**: [#3343.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/30156245611)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`