### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,9 @@
 
 ## [`7.4.0` (2026-07-25)](https://github.com/kdeldycke/meta-package-manager/compare/v7.3.0...v7.4.0)
 
+> [!NOTE]
+> `7.4.0` is available on [🐍 PyPI](https://pypi.org/project/meta-package-manager/7.4.0/) and [🐙 GitHub](https://github.com/kdeldycke/meta-package-manager/releases/tag/v7.4.0).
+
 - [mpm] Raise the click-extra floor from `8.4.0` to `8.6.0`, the release shipping the `OperationTrail` batch `✓`/`✗` trail upstreamed from mpm's own dispatch layer, which mpm now consumes from the published package instead of a git checkout.
 - [mpm] The Python and click-extra compatibility tables of the documentation read newest-first on both axes, following click-extra `8.6.0`'s `{matrix}` ordering defaults: the most recent compatibility information sits in the upper-left corner.
 - [mpm] Bump the packaging pins of click-extra to `8.6.0` and the Nix pin of extra-platforms to `13.3.1` across the Nix, MacPorts and Alpine overlays, to match mpm's dependency floors.


### PR DESCRIPTION
## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`abandoned-versions`](https://kdeldycke.github.io/repomatic/configuration.html#abandoned-versions)
- [`changelog.archive-location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-archive-location)
- [`changelog.location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-location)
- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`fix-changelog`](https://kdeldycke.github.io/repomatic/workflows.html#fix-changelog-fix-changelog)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`02807dff`](https://github.com/kdeldycke/meta-package-manager/commit/02807dff19a427f1d25b08075509a505a613bb38)
- **Job**: [`fix-changelog`](https://github.com/kdeldycke/meta-package-manager/blob/02807dff19a427f1d25b08075509a505a613bb38/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/02807dff19a427f1d25b08075509a505a613bb38/.github/workflows/changelog.yaml)
- **Run**: [#1487.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/30242823291)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`