### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1858,11 +1858,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.4"
+version = "2.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/f1/93422647dd7e461f23d254e6b2bfa687a85b53aeb4903fcdbb74474d4584/soupsieve-2.9.tar.gz", hash = "sha256:acee8417325c5653e1377dc31eccad59eb82cbc65942afe6174c53b3aaad63fc", size = 122122, upload-time = "2026-07-19T01:35:18.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d6/3185ab5ad1280319b31986898f3206dd7227cd75e293d4dba2a5e6bf27a0/soupsieve-2.9-py3-none-any.whl", hash = "sha256:a2b2c76d67df2382d245409fd71e321a571717e58463efa32ace87dcadac2c12", size = 37387, upload-time = "2026-07-19T01:35:17.106Z" },
 ]
 
 [[package]]
@@ -2151,7 +2151,7 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-mermaid"
-version = "2.0.3"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -2160,9 +2160,9 @@ dependencies = [
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/29/54cf1f7e03630ca4859caba25bc192698954d7c630377c62d1e264715c37/sphinxcontrib_mermaid-2.0.3.tar.gz", hash = "sha256:a6865ef6b65b225c5403a3170de63a04a07227cada11a4a71a6b87b4f9ed185a", size = 20764, upload-time = "2026-07-08T00:30:44.216Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/9d/bf3a48a657682c7e0445c71d916bca7ab8194454276cc22b16e7f974e502/sphinxcontrib_mermaid-2.1.0.tar.gz", hash = "sha256:13c5f9ac395cb6abf403eca34e228dc9fb3a30c9d960dbf3e40e9a8cef969549", size = 21695, upload-time = "2026-07-18T23:08:11.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/57/b39c7a69b70a3ce999732bdb57fcaac78fb3cc8e2843a3daf1c1f821bc9d/sphinxcontrib_mermaid-2.0.3-py3-none-any.whl", hash = "sha256:f001ed36a55c108f6221a2d656a441c487ee30651b54db72b7c752a20c7a66e8", size = 15401, upload-time = "2026-07-08T00:30:42.877Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/bd/d3348d62296e73a91420f0edf671450c9003ecd8704da40b1e3d9b868459/sphinxcontrib_mermaid-2.1.0-py3-none-any.whl", hash = "sha256:417cd144ec4b28852f46ba653f02ce8e538881c812111671a4c30344e87f2112", size = 16190, upload-time = "2026-07-18T23:08:10.098Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-20`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [soupsieve](https://pypi.org/project/soupsieve/) | [`2.8.4` → `2.9`](https://github.com/facelessuser/soupsieve/compare/2.8.4...2.9) | 2026-07-19 (a week ago) |
| [sphinxcontrib-mermaid](https://pypi.org/project/sphinxcontrib-mermaid/) | [`2.0.3` → `2.1.0`](https://github.com/mgaitan/sphinxcontrib-mermaid/compare/v2.0.3...v2.1.0) | 2026-07-18 (a week ago) |

### Release notes

<details>
<summary><code>soupsieve</code></summary>

#### [`2.9`](https://github.com/facelessuser/soupsieve/releases/tag/2.9)

##### 2.9

-   **NEW**: Drop Python 3.9 support.
-   **NEW**: Lazy compile selector patterns to improve initial import speed.
-   **FIX**: Correct `:nth-child`/`:nth-of-type` (and `-last-` variants) for `An+B` values whose sequence steps onto
    index 0 or onto the last child (e.g. `:nth-child(2n-2)`, `:nth-child(n-1)`, `:nth-child(n+5)`), which previously
    matched the wrong elements or nothing at all (@​gaoflow).
-   **FIX**: More efficient CSS ID matching (@​kaimandalic).
-   **FIX**: Fix inefficient trimming of comments and white space (@​kaimandalic).

</details>

<details>
<summary><code>sphinxcontrib-mermaid</code></summary>

[Changelog](https://redirect.github.com/mgaitan/sphinxcontrib-mermaid/blob/master/CHANGELOG.md)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [bracex](https://pypi.org/project/bracex/) | `3.0` | `3.0.1` | 2026-07-20 (a week ago) | 2026-07-27 (just now) |
| [certifi](https://pypi.org/project/certifi/) | `2026.6.17` | `2026.7.22` | 2026-07-22 (5 days ago) | 2026-07-29 (in 2 days) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.10.1` | `4.11.0` | 2026-07-21 (6 days ago) | 2026-07-28 (in a day) |
| [pyproject-fmt](https://pypi.org/project/pyproject-fmt/) | `2.25.3` | `2.25.4` | 2026-07-26 (a day ago) | 2026-08-02 (in 6 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9` | `2.9.1` | 2026-07-21 (6 days ago) | 2026-07-28 (in a day) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.1` | `3.13.0` | 2026-07-21 (6 days ago) | 2026-07-28 (in a day) |
| [types-boltons](https://pypi.org/project/types-boltons/) | `25.0.0.20260612` | `26.1.0.20260724` | 2026-07-24 (3 days ago) | 2026-07-31 (in 4 days) |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | `6.0.12.20260518` | `6.0.12.20260724` | 2026-07-24 (3 days ago) | 2026-07-31 (in 4 days) |
| [uritools](https://pypi.org/project/uritools/) | `6.1.2` | `6.1.3` | 2026-07-23 (4 days ago) | 2026-07-30 (in 3 days) |

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.6.0` | 2026-07-31 (in 4 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.4.0` | 2026-08-03 (in a week) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`02807dff`](https://github.com/kdeldycke/meta-package-manager/commit/02807dff19a427f1d25b08075509a505a613bb38)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/02807dff19a427f1d25b08075509a505a613bb38/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/02807dff19a427f1d25b08075509a505a613bb38/.github/workflows/autofix.yaml)
- **Run**: [#3355.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/30242823344)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`