### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history so the redundant-PR check can compute the merge base
           # between main and the open release branch (see the reconcile step below).
@@ -188,7 +188,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history so the redundant-PR check can compute the merge base
           # between main and the open release branch (see the reconcile step below).

--- a/.github/workflows/tests-install.yaml
+++ b/.github/workflows/tests-install.yaml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Install build tooling
         run: apk add --no-cache alpine-sdk
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Configure abuild
         # abuild-keygen --append registers the private key in abuild.conf; the
         # public half is copied by hand, as --install shells out to doas,
@@ -140,7 +140,7 @@ jobs:
           - windows-11-arm
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Pack
         shell: pwsh
         working-directory: packaging/choco/meta-package-manager
@@ -232,7 +232,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Guix
         run: >
           wget --quiet --output-document=guix-install.sh
@@ -308,7 +308,7 @@ jobs:
           - macos-26
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install MacPorts
         run: |
           MACOS_MAJOR="$(sw_vers -productVersion | cut -d . -f 1)"
@@ -379,7 +379,7 @@ jobs:
           - macos-26
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/tests-yay-cooldown.yaml
+++ b/.github/workflows/tests-yay-cooldown.yaml
@@ -37,7 +37,7 @@ jobs:
           pacman --sync --refresh --sysupgrade --noconfirm --needed
           base-devel curl git nodejs python sudo uv
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Write the integration test
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,7 @@ jobs:
     outputs:
       metadata: ${{ steps.metadata.outputs.metadata }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Run repomatic metadata
         id: metadata
@@ -97,7 +97,7 @@ jobs:
       # See: meta_package_manager/test_manager_homebrew.py::TestCask test.
       HOMEBREW_NO_INSTALL_FROM_API: "1"
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-tags: true
 


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-20` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/checkout](https://github.com/actions/checkout) | [`v7.0.0` → `v7.0.1`](https://github.com/actions/checkout/compare/v7.0.0...v7.0.1) | 2026-07-20 (a week ago) |

### Release notes

<details>
<summary><code>actions/checkout</code></summary>

#### [`v7.0.1`](https://github.com/actions/checkout/releases/tag/v7.0.1)

##### What's Changed
* skip running unsafe pr check if input is default by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2518
* trim only ascii whitespace for branch by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2521
* escape values passed to --unset by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2530
* Various dependency updates 

**Full Changelog**: https://redirect.github.com/actions/checkout/compare/v7...v7.0.1

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Action | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | `8.3.2` | `9.0.0` | 2026-07-21 (a week ago) | 2026-07-29 (in a day) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-action-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`a01e39eb`](https://github.com/kdeldycke/meta-package-manager/commit/a01e39eb60f02685f1907960fbbe8a78d75ae0b1)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/a01e39eb60f02685f1907960fbbe8a78d75ae0b1/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/a01e39eb60f02685f1907960fbbe8a78d75ae0b1/.github/workflows/autofix.yaml)
- **Run**: [#3369.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/30340643168)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`