### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,7 +128,7 @@ jobs:
         env:
           VERSION: ${{ steps.check.outputs.version }}
         run: >
-          uvx --no-progress 'repomatic==7.3.1' pr-body
+          uvx --no-progress 'repomatic==7.4.0' pr-body
           --template-file .github/pr-templates/update-package-spec.md
           --template-arg channel=Guix
           --template-arg version="${VERSION}"
@@ -242,7 +242,7 @@ jobs:
         env:
           VERSION: ${{ steps.check.outputs.version }}
         run: >
-          uvx --no-progress 'repomatic==7.3.1' pr-body
+          uvx --no-progress 'repomatic==7.4.0' pr-body
           --template-file .github/pr-templates/update-package-spec.md
           --template-arg channel=Nix
           --template-arg version="${VERSION}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Run repomatic metadata
         id: metadata
         run: >
-          uvx --no-progress 'repomatic==7.3.1' metadata
+          uvx --no-progress 'repomatic==7.4.0' metadata
           --format github-json --output "$GITHUB_OUTPUT"
           test_matrix test_matrix_pr
 


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-24` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [repomatic](https://pypi.org/project/repomatic/) | `7.3.1` → `7.4.0` | [⛓️ lockstep with `uses:` refs](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater) |

### Release notes

<details>
<summary><code>repomatic</code></summary>

#### [`v7.4.0`](https://github.com/kdeldycke/repomatic/releases/tag/v7.4.0)

> [!NOTE]
> `7.4.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.4.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v7.4.0).

- **Breaking:** Regroup the internal module layout: the tool catalog to `tool_registry.py`, dep-report rendering to `dep_report.py`, labels to `labels.py`, bundled data to `bundle.py`, matrix axes to `matrix_axes.py` (formerly `test_matrix.py`), PR helpers to `github/issue.py`. Import paths change; the CLI surface does not.
- **Breaking:** Rename `update-deps-graph` to `update-dep-graph` across the CLI command, autofix job, PR branch, and body template, aligning with the `dependency-graph` config key. Close any open `update-deps-graph` pull request; the next run reopens it on the new branch.
- **Breaking:** `repomatic init` component selectors are now case-sensitive, validated by the same code path as the `exclude` and `include` configuration entries.
- Lower the compiled-binary OS floors: Linux glibc `2.28`, built and self-tested in `manylinux_2_28` containers (RHEL 8, Debian 10, Ubuntu 20.04 and later), and macOS `11.0` (Apple silicon) / `10.15` (Intel) via uv's embedded python-build-standalone interpreter.
- Enforce each binary's OS floor at build time: `verify-binary` parses ELF, Mach-O and PE headers natively and no longer needs exiftool.
- Keep `tkinter` and its Tcl/Tk stack out of compiled binaries via the new `[tool.repomatic]` `nuitka.nofollow-imports` setting (default `["tkinter"]`, set to `[]` to bundle it).
- Emit man pages for repomatic's own CLI on docs builds and attach a `repomatic-manpages.tar.gz` asset to each release.
- Add `update-docs --check` to report out-of-date self-updating content and exit non-zero without writing, for CI drift detection. The docs update script must accept its own `--check` flag to participate.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v7.4.0)

</details>

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`9e014d0a`](https://github.com/kdeldycke/meta-package-manager/commit/9e014d0a3dd77f9b94aa00625ad647bd90f5bd7f)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/9e014d0a3dd77f9b94aa00625ad647bd90f5bd7f/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/9e014d0a3dd77f9b94aa00625ad647bd90f5bd7f/.github/workflows/autofix.yaml)
- **Run**: [#3413.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/30696835966)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.0`