### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -423,7 +423,7 @@ exclude-newer = "1 week"
 # Per-package overrides for freshly-published dependencies we want to pull in
 # before the global cooldown would normally let them through. Date format
 # uses an ISO 8601 calendar date for ``exclude-newer-package`` entries.
-exclude-newer-package = { click-extra = "2026-07-31T00:00:00Z", extra-platforms = "2026-08-04T00:00:00Z" }
+exclude-newer-package = { extra-platforms = "2026-08-04T00:00:00Z" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 # source-include does not honor .gitignore, so prune the build output and caches

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,6 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-click-extra = "2026-07-31T00:00:00Z"
 extra-platforms = "2026-08-04T00:00:00Z"
 
 [[package]]
@@ -249,7 +248,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "8.7.0"
+version = "8.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -262,9 +261,9 @@ dependencies = [
     { name = "wcmatch" },
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/f1/fa55bf6d6db639558606a3afe1dd0de36bf18380a24f68488969af1f0a3a/click_extra-8.7.0.tar.gz", hash = "sha256:202a1d1cae1e4fda8618e38a17d2a2bf3f0d428fb8b70895e5268ae8faa1aa8c", size = 1240106, upload-time = "2026-07-30T17:07:28.533Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/b4/f373ae3338a2364411ec78d2c891d528958acd9c45cb3165099adf864fc5/click_extra-8.8.0.tar.gz", hash = "sha256:e65ffaf55b93cc5b984d01b1e200918c44b93f0c810f27114ac9ea62eda9d871", size = 1262759, upload-time = "2026-07-31T17:54:59.264Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/aa/f3e330ff321eece86b90ef4d72ae9f1f21e1b587c01b0def67387450f77f/click_extra-8.7.0-py3-none-any.whl", hash = "sha256:fb3f2d00f9e788efc35db5c751aecda83cc53b5ac4228442891829ad431ee2f8", size = 427052, upload-time = "2026-07-30T17:07:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/71/84/aa9bf87f4a662a867671bbc10d798feef7221037d63b1173b3b0a425f88c/click_extra-8.8.0-py3-none-any.whl", hash = "sha256:747a6b1bfe1bd15a6b28cbbb4134fd0a680c3a3846366ab7089ddf663cbea101", size = 442056, upload-time = "2026-07-31T17:54:57.587Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-31`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | [`8.7.0` → `8.8.0`](https://github.com/kdeldycke/click-extra/compare/v8.7.0...v8.8.0) | 2026-07-31 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.8.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.8.0)

> [!NOTE]
> `8.8.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.8.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.8.0).

- **Breaking:** `OperationTrail` now gates its per-item and finisher elapsed times on a new `timer` argument that defaults to `None`, following `--time` / `--no-time`; its finisher no longer always shows a clock (pass `timer=True` to restore it).
- Add `spinner` and `progress_bar` arguments to `OperationTrail` to render its concurrent aggregate indicator as a spinner from the `SPINNERS` catalog or a determinate progress bar. Closes [#​1860](https://redirect.github.com/kdeldycke/click-extra/issues/1860).
- Add a `clock` argument to `OperationTrail` (`"elapsed"` by default, or `"eta"`), choosing whether a running spinner or bar counts elapsed time up or estimated time remaining down.
- Add an `OperationTrail.operation()` handle whose `mark()` records an outcome timed from when the operation began.
- Render the `OperationTrail` sequential finish-line elapsed time in the compact clock format, so a run past a minute reads `1:15`, not `75.3s`.
- Gate the estimated-time display of `click_extra.progressbar` on `--time` through a new tri-state `show_eta` argument (default `None`; Click's own default is `True`).
- Add a `trail` demo subcommand to the `click-extra` CLI, running a simulated batch behind an `OperationTrail` to showcase its sequential, spinner and progress-bar renderings in a real terminal.
- Move the self-updating block primitives (`update_blocks`, `marker_res`, `replace_region`) to a new dependency-light `click_extra.blocks` module, importable without the `sphinx` extra; they stay re-exported from `click_extra.sphinx`.
- Add a `pad` option to `replace_region` to keep the closing marker flush against the body, for regions constrained by `mdformat-footnote`.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.8.0)

</details>

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | 🧹 cleared: `8.7.0` | 2026-08-06 |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.6.0` | 2026-08-10 (in 3 days) |

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.8.0` | `8.8.1` | 2026-08-02 (5 days ago) | 2026-08-09 (in 2 days) |
| [coverage](https://pypi.org/project/coverage/) | `7.15.2` | `7.15.4` | 2026-08-06 (a day ago) | 2026-08-13 (in 6 days) |
| [packaging](https://pypi.org/project/packaging/) | `26.2` | `26.3` | 2026-08-04 (3 days ago) | 2026-08-11 (in 4 days) |
| [pyproject-fmt](https://pypi.org/project/pyproject-fmt/) | `2.26.0` | `2.27.0` | 2026-08-03 (4 days ago) | 2026-08-10 (in 3 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9.1` | `2.9.2` | 2026-08-07 (just now) | 2026-08-14 (in a week) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.0` | `3.13.2` | 2026-08-03 (4 days ago) | 2026-08-10 (in 3 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`b6e51ec2`](https://github.com/kdeldycke/meta-package-manager/commit/b6e51ec249d2956ff69610d1b5c85af48b637b63)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/b6e51ec249d2956ff69610d1b5c85af48b637b63/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/b6e51ec249d2956ff69610d1b5c85af48b637b63/.github/workflows/autofix.yaml)
- **Run**: [#3453.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/31214314366)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.5.0`