### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/docs-logos.yaml
+++ b/.github/workflows/docs-logos.yaml
@@ -38,7 +38,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.0"
+          version: "0.12.1"
 
       # PyYAML lives in the `test` group and click-extra in the main dependencies,
       # both of which meta_package_manager._docs imports: sync everything rather

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -188,7 +188,7 @@ jobs:
           # satisfying `required-version`, leaving the tool that enforces every
           # cooldown installed without one. `sync-workflow-pins` walks it forward
           # once a uv release clears the window.
-          version: "0.12.0"
+          version: "0.12.1"
       - name: Render PR body
         if: steps.check.outputs.needs_update == 'true'
         env:
@@ -308,7 +308,7 @@ jobs:
           # satisfying `required-version`, leaving the tool that enforces every
           # cooldown installed without one. `sync-workflow-pins` walks it forward
           # once a uv release clears the window.
-          version: "0.12.0"
+          version: "0.12.1"
       - name: Render PR body
         if: steps.check.outputs.needs_update == 'true'
         env:

--- a/.github/workflows/tests-install.yaml
+++ b/.github/workflows/tests-install.yaml
@@ -451,7 +451,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.0"
+          version: "0.12.1"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Run CLI via pip
@@ -479,7 +479,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.0"
+          version: "0.12.1"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Run stable CLI via pipx
@@ -536,7 +536,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.0"
+          version: "0.12.1"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Run stable CLI

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.0"
+          version: "0.12.1"
       - name: Run repomatic metadata
         id: metadata
         run: >
@@ -433,7 +433,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.0"
+          version: "0.12.1"
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,
         # relying on transparent emulation. Native extensions with Rust (e.g., test-results-parser from codecov-cli)


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-08-02` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.0` → `0.12.1` | 2026-07-31 (a week ago) |

### Release notes

<details>
<summary><code>uv</code></summary>

#### [`0.12.1`](https://github.com/astral-sh/uv/releases/tag/0.12.1)

##### Release Notes

Released on 2026-07-31.

###### Enhancements

- Add package-specific pre-release policies with `--prerelease-package` ([#​20837](https://redirect.github.com/astral-sh/uv/pull/20837))
- Support local HTML files as flat indexes ([#​20802](https://redirect.github.com/astral-sh/uv/pull/20802))
- Add Xonsh virtual environment activation scripts (`activate.xsh`) ([#​19740](https://redirect.github.com/astral-sh/uv/pull/19740))
- Preserve filesystem paths passed to `uv add --index` when updating `pyproject.toml` ([#​20817](https://redirect.github.com/astral-sh/uv/pull/20817))

###### Preview features

- Add automatic fixes to `uv check` with `--fix` ([#​20793](https://redirect.github.com/astral-sh/uv/pull/20793))
- Avoid rejecting unchanged metadata-free lockfiles when workspace dependencies share direct sources ([#​20847](https://redirect.github.com/astral-sh/uv/pull/20847))
- Honor direct URL constraints when validating metadata-free lockfiles ([#​20796](https://redirect.github.com/astral-sh/uv/pull/20796))
- Ignore malformed PEP 723 scripts discovered during project checks ([#​20784](https://redirect.github.com/astral-sh/uv/pull/20784))
- Use ty's native script exclusion in `uv check` ([#​20742](https://redirect.github.com/astral-sh/uv/pull/20742))

###### Performance

- Parse canonical uv lockfiles directly, with a fallback for other valid TOML syntax ([#​20648](https://redirect.github.com/astral-sh/uv/pull/20648))
- Accelerate SHA-256 hashing on non-Windows ARM64 platforms ([#​20805](https://redirect.github.com/astral-sh/uv/pull/20805))

###### Bug fixes

- Flush shell startup file updates before `uv tool update-shell` and `uv python update-shell` exit ([#​20842](https://redirect.github.com/astral-sh/uv/pull/20842))
- Make workspace-root dependency groups available to commands run from workspace members ([#​20840](https://redirect.github.com/astral-sh/uv/pull/20840))

... [Full release notes](https://github.com/astral-sh/uv/releases/tag/0.12.1)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.1` | `0.12.3` | 2026-08-07 (2 days ago) | 2026-08-14 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`46ad7cd3`](https://github.com/kdeldycke/meta-package-manager/commit/46ad7cd32a99bf23622e422c40cefde3c6033de1)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/46ad7cd32a99bf23622e422c40cefde3c6033de1/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/46ad7cd32a99bf23622e422c40cefde3c6033de1/.github/workflows/autofix.yaml)
- **Run**: [#3471.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/31326323613)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.6.0`