### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -442,10 +442,6 @@ required-version = ">=0.11.15"
 dependency-groups.docs = { requires-python = ">= 3.14" }
 # Cooldown period.
 exclude-newer = "1 week"
-# Per-package overrides for freshly-published dependencies we want to pull in
-# before the global cooldown would normally let them through. Date format
-# uses an ISO 8601 calendar date for ``exclude-newer-package`` entries.
-exclude-newer-package = { extra-platforms = "2026-08-04T00:00:00Z" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 # source-include does not honor .gitignore, so prune the build output and caches

--- a/uv.lock
+++ b/uv.lock
@@ -12,9 +12,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
-[options.exclude-newer-package]
-extra-platforms = "2026-08-04T00:00:00Z"
-
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"


### PR DESCRIPTION
## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | 🧹 cleared: `13.6.0` | 2026-08-10 (just now) |

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [coverage](https://pypi.org/project/coverage/) | `7.15.3` | `7.15.4` | 2026-08-06 (4 days ago) | 2026-08-13 (in 3 days) |
| [packaging](https://pypi.org/project/packaging/) | `26.2` | `26.3` | 2026-08-04 (6 days ago) | 2026-08-11 (in a day) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.11.0` | `4.11.1` | 2026-08-07 (3 days ago) | 2026-08-14 (in 4 days) |
| [pyproject-fmt](https://pypi.org/project/pyproject-fmt/) | `2.26.0` | `2.27.0` | 2026-08-03 (a week ago) | 2026-08-10 (just now) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9.1` | `2.9.2` | 2026-08-07 (3 days ago) | 2026-08-14 (in 4 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.0` | `3.13.2` | 2026-08-03 (a week ago) | 2026-08-10 (just now) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`f83da04d`](https://github.com/kdeldycke/meta-package-manager/commit/f83da04dcc6cf15aa7b70d545b46a5e61505841a)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/f83da04dcc6cf15aa7b70d545b46a5e61505841a/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/f83da04dcc6cf15aa7b70d545b46a5e61505841a/.github/workflows/autofix.yaml)
- **Run**: [#3484.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/31370394446)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.8.0`