### PR TITLE
Bump minor version to `v7.7.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`7.6.2.dev0` (unreleased)](https://github.com/kdeldycke/meta-package-manager/compare/v7.6.1...main)
+## [`7.7.0.dev0` (unreleased)](https://github.com/kdeldycke/meta-package-manager/compare/v7.6.1...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -8,7 +8,7 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.6809571
-version: 7.6.2.dev0
+version: 7.7.0.dev0
 # The release date is kept up to date by the external workflows. See:
 # https://github.com/kdeldycke/workflows/blob/33b704b489c1aa18b7b7efbf963e153e91e1c810/.github/workflows/changelog.yaml#L135-L137
 date-released: 2026-08-11

--- a/gnome-shell/mpm@kdeldycke.github.io/metadata.json
+++ b/gnome-shell/mpm@kdeldycke.github.io/metadata.json
@@ -6,5 +6,5 @@
 	"shell-version": ["46", "47", "48", "49", "50"],
 	"url": "https://github.com/kdeldycke/meta-package-manager",
 	"uuid": "mpm@kdeldycke.github.io",
-	"version-name": "7.6.2.dev0"
+	"version-name": "7.7.0.dev0"
 }

--- a/meta_package_manager/__init__.py
+++ b/meta_package_manager/__init__.py
@@ -21,4 +21,4 @@ point lives in {mod}`meta_package_manager.cli`.
 
 from __future__ import annotations
 
-__version__ = "7.6.2.dev0"
+__version__ = "7.7.0.dev0"

--- a/meta_package_manager/bar_plugin.py
+++ b/meta_package_manager/bar_plugin.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # <xbar.title>Meta Package Manager</xbar.title>
-# <xbar.version>7.6.2.dev0</xbar.version>
+# <xbar.version>7.7.0.dev0</xbar.version>
 # <xbar.author>Kevin Deldycke</xbar.author>
 # <xbar.author.github>kdeldycke</xbar.author.github>
 # <xbar.desc>List outdated packages and manage upgrades.</xbar.desc>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.8" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "meta-package-manager"
-version = "7.6.2.dev0"
+version = "7.7.0.dev0"
 description = "🎁 wraps all package managers with a unifying CLI"
 readme = "readme.md"
 keywords = [
@@ -331,7 +331,7 @@ optional-dependencies.toml = [ "click-extra[toml]" ]
 optional-dependencies.xml = [ "click-extra[xml]" ]
 optional-dependencies.yaml = [ "click-extra[yaml]" ]
 urls.Changelog = "https://github.com/kdeldycke/meta-package-manager/blob/main/changelog.md"
-urls.Download = "https://github.com/kdeldycke/meta-package-manager/releases/tag/v7.6.2.dev0"
+urls.Download = "https://github.com/kdeldycke/meta-package-manager/releases/tag/v7.7.0.dev0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/meta-package-manager"
 urls.Issues = "https://github.com/kdeldycke/meta-package-manager/issues"
@@ -473,8 +473,8 @@ build-backend.source-include = [
 product-name = "Meta Package Manager"
 file-description = "🎁 wraps all package managers with a unifying CLI"
 copyright = "Kevin Deldycke <kevin@deldycke.com> and contributors. Distributed under GPL-2.0-or-later license."
-file-version = "7.6.2"
-product-version = "7.6.2"
+file-version = "7.7.0"
+product-version = "7.7.0"
 # Each platform needs its native icon format (all rendered from icon.svg):
 # .icns for macOS, .ico for Windows, .png for Linux. Passing a non-native
 # image (like a PNG to --windows-icon-from-ico) makes Nuitka require the
@@ -598,7 +598,7 @@ report.fail_under = 78
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "7.6.2.dev0"
+current_version = "7.7.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/uv.lock
+++ b/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "meta-package-manager"
-version = "7.6.2.dev0"
+version = "7.7.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

## To bump version to `v7.7.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`bump-version`](https://kdeldycke.github.io/repomatic/workflows.html#bump-version-bump-version)
- **Trigger**: `workflow_run`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`c9d9eff1`](https://github.com/kdeldycke/meta-package-manager/commit/c9d9eff1a4e03127b784763ef64a0adb1214e1b4)
- **Job**: [`bump-version`](https://github.com/kdeldycke/meta-package-manager/blob/c9d9eff1a4e03127b784763ef64a0adb1214e1b4/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/c9d9eff1a4e03127b784763ef64a0adb1214e1b4/.github/workflows/changelog.yaml)
- **Run**: [#1768.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/31485837711)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.9.0`