### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
 
 ## [`7.6.1` (2026-08-11)](https://github.com/kdeldycke/meta-package-manager/compare/v7.6.0...v7.6.1)
 
+> [!NOTE]
+> `7.6.1` is available on [🐍 PyPI](https://pypi.org/project/meta-package-manager/7.6.1/) and [🐙 GitHub](https://github.com/kdeldycke/meta-package-manager/releases/tag/v7.6.1).
+
 - [mpm] Fix `upgrade <packages>` and `remove` dying on an unhandled `CLIError` traceback when any selected manager's installed-package query failed. The manager is now skipped with a warning, and the packages the other managers carry are still acted on.
 - [mpm] Count a manager whose failed command was raised to its caller in the end-of-run error summary, the serialized `errors` payload and the `✓`/`✗` trail. One reporting `Could not list installed packages.` was previously scored `✓`.
 - [bar-plugin] Fix the `uv` launch candidate silently re-locking whatever project the plugin's working directory landed in: it now runs frozen, pinned to the folder its lockfile was found in.


### PR DESCRIPTION
## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`abandoned-versions`](https://kdeldycke.github.io/repomatic/configuration.html#abandoned-versions)
- [`changelog.archive-location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-archive-location)
- [`changelog.location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-location)
- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`fix-changelog`](https://kdeldycke.github.io/repomatic/workflows.html#fix-changelog-fix-changelog)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`c7e4c765`](https://github.com/kdeldycke/meta-package-manager/commit/c7e4c765d87c38b17baaaa7de4f485ad1c9a6a8c)
- **Job**: [`fix-changelog`](https://github.com/kdeldycke/meta-package-manager/blob/c7e4c765d87c38b17baaaa7de4f485ad1c9a6a8c/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/c7e4c765d87c38b17baaaa7de4f485ad1c9a6a8c/.github/workflows/changelog.yaml)
- **Run**: [#1763.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/31484166071)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.9.0`