### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/docs-logos.yaml
+++ b/.github/workflows/docs-logos.yaml
@@ -48,7 +48,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.1"
+          version: "0.12.5"
 
       # PyYAML lives in the `test` group and click-extra in the main dependencies,
       # both of which meta_package_manager._docs imports: sync everything rather

--- a/.github/workflows/docs-screenshots.yaml
+++ b/.github/workflows/docs-screenshots.yaml
@@ -145,7 +145,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.1"
+          version: "0.12.5"
 
       # The oxipng `format-images` provisions, keyed on the file carrying the
       # repomatic pin that decides its version: a bump misses the cache once and
@@ -214,7 +214,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.1"
+          version: "0.12.5"
 
       # The driver renders the menu through `BarPluginRenderer`, so it needs the
       # package and its dependencies rather than a bare interpreter.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -220,7 +220,7 @@ jobs:
           # satisfying `required-version`, leaving the tool that enforces every
           # cooldown installed without one. `sync-workflow-pins` walks it forward
           # once a uv release clears the window.
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Render PR body
         if: steps.check.outputs.needs_update == 'true'
         env:
@@ -341,7 +341,7 @@ jobs:
           # satisfying `required-version`, leaving the tool that enforces every
           # cooldown installed without one. `sync-workflow-pins` walks it forward
           # once a uv release clears the window.
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Render PR body
         if: steps.check.outputs.needs_update == 'true'
         env:

--- a/.github/workflows/tests-gnome-extension.yaml
+++ b/.github/workflows/tests-gnome-extension.yaml
@@ -143,7 +143,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.1"
+          version: "0.12.5"
       # shexli exits 0 whatever it finds, errors included, so its exit code
       # cannot gate anything: the JSON summary is the only usable signal. The
       # report is teed to the log first, or a red job would say nothing about

--- a/.github/workflows/tests-install.yaml
+++ b/.github/workflows/tests-install.yaml
@@ -557,7 +557,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Run CLI via pip
@@ -586,7 +586,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Run stable CLI via pipx
@@ -645,7 +645,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Run stable CLI

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -94,7 +94,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Run repomatic metadata
         id: metadata
         run: >
@@ -448,7 +448,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Install Python ${{ matrix.python-version }}
         # If UV cannot find the requested Python version, it exits with code 2, which let the job pass unnoticed on
         # Windows. So we force the shell to bash, even on Windows, and "set -e" to ensure any error in the install
@@ -594,7 +594,7 @@ jobs:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
           # uv release clears the cooldown window.
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Install project


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `1 week`: releases after `2026-08-20` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.1` → `0.12.5` | 2026-08-14 (a week ago) |

### Release notes

<details>
<summary><code>uv</code></summary>

#### [`0.12.2`](https://github.com/astral-sh/uv/releases/tag/0.12.2)

##### Release Notes

Released on 2026-08-05.

###### Python

- Add CPython 3.15.0rc1 ([#​20948](https://redirect.github.com/astral-sh/uv/pull/20948))
- Add CPython 3.14.7 ([#​20971](https://redirect.github.com/astral-sh/uv/pull/20971))

###### Enhancements

- Ensure diagnostic hints end with a newline to prevent malformed terminal output ([#​20959](https://redirect.github.com/astral-sh/uv/pull/20959))

###### Preview features

- Audit one or all installed tools with `uv tool audit` ([#​20921](https://redirect.github.com/astral-sh/uv/pull/20921))
- Report physically reclaimed disk space during cache cleanup with the `cache-physical-space` preview feature ([#​20925](https://redirect.github.com/astral-sh/uv/pull/20925))

###### Configuration

- Add `UV_RUN_RLIMIT_NOFILE` to set the open-file limit for commands launched by `uv run` ([#​20926](https://redirect.github.com/astral-sh/uv/pull/20926))

###### Performance

- Speed up `uv.lock` parsing for wheel entries ([#​20881](https://redirect.github.com/astral-sh/uv/pull/20881))
- Speed up `uv.lock` parsing for source distribution entries ([#​20882](https://redirect.github.com/astral-sh/uv/pull/20882))
- Speed up filename extraction from distribution URLs ([#​20879](https://redirect.github.com/astral-sh/uv/pull/20879))
- Reduce filesystem metadata lookups during bytecode compilation ([#​20928](https://redirect.github.com/astral-sh/uv/pull/20928))
- Reuse file metadata when building source distributions ([#​20927](https://redirect.github.com/astral-sh/uv/pull/20927))

###### Bug fixes

- Preserve compatibility with older uv versions when recording artifact sizes in cached wheels and source distributions ([#​20963](https://redirect.github.com/astral-sh/uv/pull/20963))
- Avoid including workspace-root default dependency groups when syncing or exporting a selected workspace member unless explicitly requested ([#​20930](https://redirect.github.com/astral-sh/uv/pull/20930))

###### Documentation

... [Full release notes](https://github.com/astral-sh/uv/releases/tag/0.12.2)

#### [`0.12.3`](https://github.com/astral-sh/uv/releases/tag/0.12.3)

##### Release Notes

Released on 2026-08-07.

###### Python

- Add CPython 3.13.15 ([#​20997](https://redirect.github.com/astral-sh/uv/pull/20997))

###### Preview features

- Add `--output-format` to select automatic, human-readable, or raw-byte output for `uv cache size` ([#​20992](https://redirect.github.com/astral-sh/uv/pull/20992))
- Preserve JSON output from `uv workspace metadata --quiet` while suppressing diagnostics ([#​20991](https://redirect.github.com/astral-sh/uv/pull/20991))
- Reduce memory usage for large workspaces by streaming `uv workspace metadata` JSON output ([#​20990](https://redirect.github.com/astral-sh/uv/pull/20990))

###### Performance

- Reduce Linux startup latency by initializing the workspace cache before spawning another thread ([#​20989](https://redirect.github.com/astral-sh/uv/pull/20989))
- Reuse compiled workspace exclusion patterns during workspace discovery ([#​20988](https://redirect.github.com/astral-sh/uv/pull/20988))
- Speed up conflict-heavy resolutions by avoiding materialized range complements ([#​20982](https://redirect.github.com/astral-sh/uv/pull/20982))
- Avoid slow procfs reads during Python interpreter discovery on Linux ([#​20987](https://redirect.github.com/astral-sh/uv/pull/20987))

###### Documentation

- Add PEP 740 attestations to the GitHub Actions publishing example ([#​20986](https://redirect.github.com/astral-sh/uv/pull/20986))
- Restrict the GitHub Actions publishing example to Python version tags ([#​20973](https://redirect.github.com/astral-sh/uv/pull/20973))
- Correct `--python-pin` to `--pin-python` in the `uv init --bare` example ([#​20876](https://redirect.github.com/astral-sh/uv/pull/20876))

##### Install uv 0.12.3

###### Install prebuilt binaries via shell script

```sh
curl --proto '=https' --tlsv1.2 -LsSf https://releases.astral.sh/github/uv/releases/download/0.12.3/uv-installer.sh | sh
```

###### Install prebuilt binaries via powershell script

```sh

... [Full release notes](https://github.com/astral-sh/uv/releases/tag/0.12.3)

#### [`0.12.4`](https://github.com/astral-sh/uv/releases/tag/0.12.4)

##### Release Notes

Released on 2026-08-13.

###### Enhancements

- Prefer post-quantum key exchange and enable opt-in TLS diagnostics ([#​21054](https://redirect.github.com/astral-sh/uv/pull/21054))
- Accept whitespace before versions in noncompliant wildcard comparisons such as `Requires-Python: >= 3.5.*` ([#​21012](https://redirect.github.com/astral-sh/uv/pull/21012))
- Report a specific error when a PEP 723 closing tag contains trailing whitespace or other content ([#​20944](https://redirect.github.com/astral-sh/uv/pull/20944))
- Omit source-span carets from diagnostics for empty PEP 508 requirements ([#​21094](https://redirect.github.com/astral-sh/uv/pull/21094))

###### Preview features

- Add `uv check --no-install-project` and respect `UV_NO_INSTALL_PROJECT` to install dependencies without building or installing the project ([#​21085](https://redirect.github.com/astral-sh/uv/pull/21085))
- Make the ty subprocess invoked by `uv check` honor uv's color and progress settings, including quiet mode ([#​21086](https://redirect.github.com/astral-sh/uv/pull/21086))

###### Performance

- Speed up resolutions with long runs of unavailable package versions by coalescing gaps in the resolver's version ranges ([#​20804](https://redirect.github.com/astral-sh/uv/pull/20804))
- Speed up Simple API parsing by deserializing PyPI and Pyx file metadata directly ([#​21041](https://redirect.github.com/astral-sh/uv/pull/21041))

###### Bug fixes

- Use windowed `pythonw.exe` launchers for virtual environments created from managed Python minor-version links ([#​19235](https://redirect.github.com/astral-sh/uv/pull/19235))
- Allow `uv lock` to proceed when `.venv` is an unusable project environment ([#​21068](https://redirect.github.com/astral-sh/uv/pull/21068))
- Respect `fork-strategy` when ordering forks created from `environments` or existing lockfile `resolution-markers` ([#​21000](https://redirect.github.com/astral-sh/uv/pull/21000))

... [Full release notes](https://github.com/astral-sh/uv/releases/tag/0.12.4)

#### [`0.12.5`](https://github.com/astral-sh/uv/releases/tag/0.12.5)

##### Release Notes

Released on 2026-08-14.

###### Python

- Add CPython 3.10.21, 3.11.16, and 3.12.14 ([#​21138](https://redirect.github.com/astral-sh/uv/pull/21138))
- Prefer newer versions and standard variants when selecting between equally prioritized Python interpreters ([#​21134](https://redirect.github.com/astral-sh/uv/pull/21134))

###### Enhancements

- Simplify errors and hints for invalid editable requirements, and redact credentials in requirement URLs ([#​21130](https://redirect.github.com/astral-sh/uv/pull/21130))

###### Preview features

- Allow `--index` and `--default-index` to select configured package indexes by name with the `index-by-name` preview feature ([#​17455](https://redirect.github.com/astral-sh/uv/pull/17455))
- Include distribution artifact URLs and hashes in CycloneDX SBOM exports by default ([#​21131](https://redirect.github.com/astral-sh/uv/pull/21131))
- Fall back to logical file sizes when using `cache-physical-space` on filesystems that do not support physical-space accounting ([#​21133](https://redirect.github.com/astral-sh/uv/pull/21133))

###### Bug fixes

- Resolve relative package index paths in PEP 723 scripts against the script directory ([#​21097](https://redirect.github.com/astral-sh/uv/pull/21097))

##### Install uv 0.12.5

###### Install prebuilt binaries via shell script

```sh
curl --proto '=https' --tlsv1.2 -LsSf https://releases.astral.sh/github/uv/releases/download/0.12.5/uv-installer.sh | sh
```

###### Install prebuilt binaries via powershell script

```sh
powershell -ExecutionPolicy Bypass -c "irm https://releases.astral.sh/github/uv/releases/download/0.12.5/uv-installer.ps1 | iex"
```

##### Download uv 0.12.5

|  File  | Platform | Checksum |
|--------|----------|----------|

... [Full release notes](https://github.com/astral-sh/uv/releases/tag/0.12.5)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.5` | `0.12.6` | 2026-08-25 (2 days ago) | 2026-09-01 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)
- [`workflow-pins.sync`](https://repomatic.net/configuration#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://repomatic.net/workflows#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`9d972552`](https://github.com/kdeldycke/meta-package-manager/commit/9d9725520e24ebdb4f925a03030bc0c6a0f32e78)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/9d9725520e24ebdb4f925a03030bc0c6a0f32e78/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/9d9725520e24ebdb4f925a03030bc0c6a0f32e78/.github/workflows/autofix.yaml)
- **Run**: [#3796.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/33079677189)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.13.0`
