### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/check-opensuse-spec.yaml
+++ b/.github/workflows/check-opensuse-spec.yaml
@@ -215,7 +215,7 @@ jobs:
             sleep 15
           done
           exit 1
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: opensuse-rpm
       - name: Install the built RPM

--- a/.github/workflows/docs-logos.yaml
+++ b/.github/workflows/docs-logos.yaml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a

--- a/.github/workflows/docs-screenshots.yaml
+++ b/.github/workflows/docs-screenshots.yaml
@@ -140,7 +140,7 @@ jobs:
           path: ${{ runner.temp }}/capture/*.log
           if-no-files-found: warn
 
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
@@ -209,7 +209,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -213,7 +213,7 @@ jobs:
       - name: Update package definition to latest release
         if: steps.check.outputs.needs_update == 'true'
         run: python3 packaging/guix/update.py
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         if: steps.check.outputs.needs_update == 'true'
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
@@ -299,7 +299,7 @@ jobs:
           # Full history so the redundant-PR check can compute the merge base
           # between main and the open release branch (see the reconcile step below).
           fetch-depth: 0
-      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
       - name: Check for new release
         id: check
         env:
@@ -334,7 +334,7 @@ jobs:
       - name: Update package definition to latest release
         if: steps.check.outputs.needs_update == 'true'
         run: python3 packaging/nix/update.py
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         if: steps.check.outputs.needs_update == 'true'
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv

--- a/.github/workflows/tests-gnome-extension.yaml
+++ b/.github/workflows/tests-gnome-extension.yaml
@@ -138,7 +138,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a

--- a/.github/workflows/tests-install.yaml
+++ b/.github/workflows/tests-install.yaml
@@ -447,7 +447,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
-      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix-env --install --attr nixpkgs.meta-package-manager
@@ -469,7 +469,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           # Nix leaves the build sandbox off on macOS, while Hydra and
@@ -552,7 +552,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
@@ -581,7 +581,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
@@ -640,7 +640,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -89,7 +89,7 @@ jobs:
       metadata: ${{ steps.metadata.outputs.metadata }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
@@ -443,7 +443,7 @@ jobs:
       # `dotnet tool` needs no setup step.
 
       - name: Install UV
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a
@@ -589,7 +589,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-tags: true
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Pin what CI downloads: unpinned, setup-uv installs the newest uv
           # satisfying `required-version`. `sync-workflow-pins` bumps it once a


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `1 week`: releases after `2026-08-20` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/download-artifact](https://github.com/actions/download-artifact) | [`v7.0.0` → `v8.0.1`](https://github.com/actions/download-artifact/compare/v7.0.0...v8.0.1) | 2026-03-11 (6 months ago) |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | [`v9.0.0` → `v10.0.1`](https://github.com/astral-sh/setup-uv/compare/v9.0.0...v10.0.1) | 2026-08-14 (a week ago) |
| [cachix/install-nix-action](https://github.com/cachix/install-nix-action) | [`v31.11.0` → `v31.11.1`](https://github.com/cachix/install-nix-action/compare/v31.11.0...v31.11.1) | 2026-08-13 (2 weeks ago) |

### Release notes

<details>
<summary><code>actions/download-artifact</code></summary>

#### [`v8.0.0`](https://github.com/actions/download-artifact/releases/tag/v8.0.0)

##### v8 - What's new

> [!IMPORTANT]
> actions/download-artifact@v8 has been migrated to an ESM module. This should be transparent to the caller but forks might need to make significant changes.

> [!IMPORTANT]
> Hash mismatches will now error by default. Users can override this behavior with a setting change (see below).

###### Direct downloads

To support direct uploads in `actions/upload-artifact`, the action will no longer attempt to unzip all downloaded files. Instead, the action checks the `Content-Type` header ahead of unzipping and skips non-zipped files. Callers wishing to download a zipped file as-is can also set the new `skip-decompress` parameter to `true`.

###### Enforced checks (breaking)

A previous release introduced digest checks on the download. If a download hash didn't match the expected hash from the server, the action would log a warning. Callers can now configure the behavior on mismatch with the `digest-mismatch` parameter. To be secure by default, we are now defaulting the behavior to `error` which will fail the workflow run.

###### ESM

To support new versions of the @​actions/* packages, we've upgraded the package to ESM.

##### What's Changed
* Don't attempt to un-zip non-zipped downloads by @​danwkennedy in https://redirect.github.com/actions/download-artifact/pull/460
* Add a setting to specify what to do on hash mismatch and default it to `error` by @​danwkennedy in https://redirect.github.com/actions/download-artifact/pull/461

**Full Changelog**: https://redirect.github.com/actions/download-artifact/compare/v7...v8.0.0

#### [`v8.0.1`](https://github.com/actions/download-artifact/releases/tag/v8.0.1)

##### What's Changed

* Support for CJK characters in the artifact name by @​danwkennedy in https://redirect.github.com/actions/download-artifact/pull/471
* Add a regression test for artifact name + content-type mismatches by @​danwkennedy in https://redirect.github.com/actions/download-artifact/pull/472

**Full Changelog**: https://redirect.github.com/actions/download-artifact/compare/v8...v8.0.1

</details>

<details>
<summary><code>astral-sh/setup-uv</code></summary>

#### [`v10.0.0`](https://github.com/astral-sh/setup-uv/releases/tag/v10.0.0)

##### Changes

Another breaking release, directly after v9.0.0 but we think the added security justifies that.

###### Extra security by default

If you use the default `enable-cache: auto` this will now **DISABLE THE CACHE** to protect against cache poisoning for the following events:

- `pull_request_target`
- `workflow_run`
- `release`

You can read the full reasoning in https://redirect.github.com/astral-sh/setup-uv/issues/984

###### `version: latest-known`

```yaml
- name: Install the latest version of uv known to setup-uv
  uses: astral-sh/setup-uv@v10.0.0
  with:
    version: "latest-known"
```

This will now install the latest version with a checksum that is known by this action. The [known `uv` checksums](https://redirect.github.com/astral-sh/setup-uv/blob/4f6036f71cec78afb113b323f220c9185d983c12/src/download/checksum/known-checksums.ts) are automatically updated but will take a release of this action to take effect. You won't be always using the latest & greatest but you will have an extra level of security.

###### Read python version from `.tool-versions`

```yaml
- name: Install uv based on the version defined in .tool-versions and also set python
  uses: astral-sh/setup-uv@v10.0.0
  with:
    version-file: "pyproject.toml"
```

Will now also set the python version if it is defined in `.tool-versions`. You can read the details [in the docs](https://redirect.github.com/astral-sh/setup-uv/blob/main/docs/advanced-version-configuration.md#install-a-version-defined-in-a-requirements-or-config-file)

##### 🚨 Breaking changes

- Disable automatic caching for sensitive events @​eifinger (#​992)

##### 🐛 Bug fixes

- Reject paths in .tool-versions @​eifinger (#​1007)

##### 🚀 Enhancements

- Read Python version from .tool-versions @​eifinger (#​996)
- Add latest-known version selector @​eifinger (#​993)

##### 🧰 Maintenance

- Require pull requests for Dependabot rollups @​eifinger (#​1005)

... [Full release notes](https://github.com/astral-sh/setup-uv/releases/tag/v10.0.0)

#### [`v10.0.1`](https://github.com/astral-sh/setup-uv/releases/tag/v10.0.1)

##### Changes

Thank you @​arguile- for making this action more resilient.

##### 🐛 Bug fixes

- Tolerate transient manifest timeouts @​arguile- (#​1016)

##### 🧰 Maintenance

- chore: update known checksums for 0.12.4 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1017)

##### 📚 Documentation

- docs: update version references to v10.0.0 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1014)

</details>

<details>
<summary><code>cachix/install-nix-action</code></summary>

#### [`v31.11.1`](https://github.com/cachix/install-nix-action/releases/tag/v31.11.1)

##### What's Changed
* nix: 2.35.1 -> 2.35.2 by @​github-actions[bot] in https://redirect.github.com/cachix/install-nix-action/pull/281
  Fixes a crash ([`Assertion '!awake.empty()' failed`](https://redirect.github.com/NixOS/nix/issues/16005)) that could abort builds.

**Full Changelog**: https://redirect.github.com/cachix/install-nix-action/compare/v31.11.0...v31.11.1

</details>

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`action-pins.sync`](https://repomatic.net/configuration#action-pins-sync)
- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://repomatic.net/workflows#sync-action-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`9d972552`](https://github.com/kdeldycke/meta-package-manager/commit/9d9725520e24ebdb4f925a03030bc0c6a0f32e78)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/meta-package-manager/blob/9d9725520e24ebdb4f925a03030bc0c6a0f32e78/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/9d9725520e24ebdb4f925a03030bc0c6a0f32e78/.github/workflows/autofix.yaml)
- **Run**: [#3796.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/33079677189)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.13.0`
