### PR TITLE
Sync runner images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -984,6 +984,7 @@ test-matrix.exclude = [
   { os = "macos-26", python-version = "3.15" },
   { os = "windows-2025", python-version = "3.15" },
 ]
+test-matrix.unstable = [{ os = "ubuntu-26.04" }]
 # Sync optional-dependencies into the build venv so the Nuitka binary ships
 # every feature gated behind try/except imports in click-extra and mpm:
 #   - sbom-offline: cyclonedx-python-lib + spdx-tools, for `mpm sbom --spdx`
@@ -2013,6 +2014,9 @@ description = "Cygwin, GNU/Hurd, Haiku, IBM AIX, IBM i, illumos, Solaris"
 name = "🖥 platform: Windows"
 color = "bfd4f2"
 description = "Windows"
+
+[tool.repomatic.test-matrix.variations]
+os = ["ubuntu-26.04"]
 
 [tool.gitleaks]
 # Extend gitleaks' built-in ruleset instead of replacing it: this section is


### PR DESCRIPTION
A runner image this repository runs has moved in GitHub's [available-images table](https://github.com/actions/runner-images#available-images). This pull request carries the mechanical half of the response; deciding whether to take it is the point of opening it rather than committing it.

| Change | What | Why | Passed over |
| :-- | :-- | :-- | :-- |
| 🆕 probe | `ubuntu-26.04` joins the matrix as `continue-on-error`, beside `ubuntu-22.04` | Ubuntu 26.04 supersedes Ubuntu 22.04 | — |

**A 🔴 retirement moves jobs onto released ground.** A released successor always wins over a preview: a forced move should not trade a known deadline for an unknown one. Where a newer preview was passed over, it is named under **Passed over** so you can take it instead if the capacity risk is worth the freshness.

**A 🆕 probe changes nothing you depend on.** The image joins the full test matrix as a `continue-on-error` cell, so it cannot fail the build. The point is to start exercising it now: a dependency that breaks on a new image surfaces here months before the image is one you have to be on, while there is still time to report it upstream.

Only a strictly newer *version* is proposed as a probe. A same-version variant carrying a different toolchain is a different image rather than a newer one, and is left alone.

> [!IMPORTANT]
> The CI run on this pull request is the evidence. Read it before merging, and check `repomatic job-timings` for what the image costs in whole-job wall-clock, not just whether it passes.

To decline a proposal permanently, name the label in `pyproject.toml` rather than closing this pull request, which only brings it back on the next push:

```toml
[tool.repomatic.sync-runner-images]
ignore = ["the-label"]
```

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`



> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-runner-images`](https://repomatic.net/workflows#sync-runner-images-sync-runner-images)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`689a9ebb`](https://github.com/kdeldycke/meta-package-manager/commit/689a9ebbdfc9152d3b85adc56a05ef20eaf51e80)
- **Job**: [`sync-runner-images`](https://github.com/kdeldycke/meta-package-manager/blob/689a9ebbdfc9152d3b85adc56a05ef20eaf51e80/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/689a9ebbdfc9152d3b85adc56a05ef20eaf51e80/.github/workflows/autofix.yaml)
- **Run**: [#3892.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/34106576220)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`
