### PR TITLE
Typo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2035,7 +2035,7 @@
 - [bar-plugin] Rewrite BitBar plugin based on `mpm`. Closes [#13](https://github.com/kdeldycke/meta-package-manager/issues/13).
 - [bar-plugin] Render errors with a monospaced font in BitBar plugin.
 - [mpm] Add missing `CHANGES.rst` in `MANIFEST.in`.
-- [mpm] Make wheels generated under Python 2 environnment available for
+- [mpm] Make wheels generated under Python 2 environment available for
   Python 3 too.
 - [mpm] Only show latest changes in the long description of the package
   instead of the full changelog.

--- a/meta_package_manager/managers/pear.py
+++ b/meta_package_manager/managers/pear.py
@@ -53,7 +53,7 @@ class PEAR(PackageManager):
     ```{important}
     Whether that needs root is a property of the PHP install, not of PEAR: a
     distribution's `php_dir` is `/usr/share/php` and refuses an ordinary user
-    with `Cannot install, php_dir for channel "pear.php.net" is not writeable
+    with `Cannot install, php_dir for channel "pear.php.net" is not writable
     by the current user`. So the mutating operations carry privileged markers
     but leave them dormant, exactly as the other language managers do: `mpm
     --sudo`, or a `[mpm.overrides.pear] sudo = true` entry, escalates them.

--- a/tests/destructive_plan.py
+++ b/tests/destructive_plan.py
@@ -485,7 +485,7 @@ def pear_install_blocked() -> bool:
     """Whether `pear install` cannot complete on this host.
 
     PEAR gates an install on exactly one test of its own, refusing with `Cannot
-    install, php_dir for channel "pear.php.net" is not writeable by the current
+    install, php_dir for channel "pear.php.net" is not writable by the current
     user`, so the same directory is probed here rather than the platform
     guessed from. A distribution's PHP roots that directory at `/usr/share/php`
     and owns it as root, blocking an unelevated round-trip; a PEAR relocated to


### PR DESCRIPTION
> [!TIP]
> Manage false positives and customize spell-checking rules via [`[tool.typos]`](https://github.com/crate-ci/typos/blob/master/docs/reference.md) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/meta-package-manager/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`fix-typos`](https://repomatic.net/workflows#fix-typos-fix-typos)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`fbfb7d78`](https://github.com/kdeldycke/meta-package-manager/commit/fbfb7d781416361b1b43e7d1a6c2b90d94f8613e)
- **Job**: [`fix-typos`](https://github.com/kdeldycke/meta-package-manager/blob/fbfb7d781416361b1b43e7d1a6c2b90d94f8613e/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/meta-package-manager/blob/fbfb7d781416361b1b43e7d1a6c2b90d94f8613e/.github/workflows/autofix.yaml)
- **Run**: [#3915.1](https://github.com/kdeldycke/meta-package-manager/actions/runs/34682084755)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.15.0`
